### PR TITLE
bugfix: remove invalid chars from wrangler.toml

### DIFF
--- a/worker-aws/wrangler.toml
+++ b/worker-aws/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-cobol/wrangler.toml
+++ b/worker-cobol/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-durable-objects/wrangler.toml
+++ b/worker-durable-objects/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-emscripten/wrangler.toml
+++ b/worker-emscripten/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-mysql/wrangler.toml
+++ b/worker-mysql/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 main = "dist/index.mjs"

--- a/worker-postgres/wrangler.toml
+++ b/worker-postgres/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 main = "dist/index.mjs"

--- a/worker-router/wrangler.toml
+++ b/worker-router/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-rust/wrangler.toml
+++ b/worker-rust/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 main = "build/worker/shim.mjs"

--- a/worker-sites-react/wrangler.toml
+++ b/worker-sites-react/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 main = "./worker/index.js"

--- a/worker-sites/wrangler.toml
+++ b/worker-sites/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker-speedtest/wrangler.toml
+++ b/worker-speedtest/wrangler.toml
@@ -1,4 +1,4 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 compatibility_date = "2022-05-03"

--- a/worker-typescript/wrangler.toml
+++ b/worker-typescript/wrangler.toml
@@ -1,4 +1,4 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 compatibility_date = "2022-05-03"

--- a/worker-websocket/wrangler.toml
+++ b/worker-websocket/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,5 +1,5 @@
-name = "<< todo >>"
-account_id = "<< todo >>"
+name = ""
+account_id = ""
 workers_dev = true
 
 compatibility_date = "2022-05-03"


### PR DESCRIPTION
## Steps to Reproduce

1. Clone repo
2. Change into an example dir e.g. `cd worker-typescript`
3. Install deps `npm i`
4. Fire up dev mode `npx wrangler dev src/index.ts --local`
5. Alternatively just visit https://workers.new/typescript and you'll see the below error in the console:

```
$ wrangler dev src/index.ts --local
 ⛅️ wrangler 2.0.1 
-------------------

✘ [ERROR] Processing wrangler.toml configuration:

    - Expected "name" to be of type string, alphanumeric and lowercase with dashes only but got "<<
  todo >>".
```

PR removes all occurrences of `<< todo >>` in each examples `wrangler.toml`.