### PR TITLE
hotfix stackblitz experience

### DIFF
--- a/packages/workers.new/src/index.ts
+++ b/packages/workers.new/src/index.ts
@@ -5,7 +5,7 @@
 // stackblitz repository source
 const source = 'github/cloudflare/templates/tree/main';
 
-const redirects: Record<string, [string, string, string]> = {
+const redirects: Record<string, [string, string, string, string?]> = {
 	'/durable-objects': ['worker-durable-objects', 'index.js', 'Workers Durable Objects counter'],
 	'/example-wordle': ['worker-example-wordle', 'src/index.ts', 'Workers Wordle example'],
 	'/router': ['worker-router', 'index.js', 'Workers router'],
@@ -22,11 +22,11 @@ const redirects: Record<string, [string, string, string]> = {
 const worker: ExportedHandler = {
 	fetch(request) {
 		const { pathname } = new URL(request.url);
-		const [subdir, file, title] = redirects[pathname] || [];
+		const [subdir, file, title, terminal] = redirects[pathname] || [];
 
 		if (subdir) {
 			const focus = encodeURIComponent(file);
-			const target = `https://stackblitz.com/fork/${source}/${subdir}?file=${focus}&title=${title}`;
+			const target = `https://stackblitz.com/fork/${source}/${subdir}?file=${focus}&title=${title}&terminal=${terminal || "start-stackblitz"}`;
 			return Response.redirect(target, 302);
 		}
 

--- a/packages/workers.new/src/index.ts
+++ b/packages/workers.new/src/index.ts
@@ -26,7 +26,9 @@ const worker: ExportedHandler = {
 
 		if (subdir) {
 			const focus = encodeURIComponent(file);
-			const target = `https://stackblitz.com/fork/${source}/${subdir}?file=${focus}&title=${title}&terminal=${terminal || "start-stackblitz"}`;
+			const target = `https://stackblitz.com/fork/${source}/${subdir}?file=${focus}&title=${title}&terminal=${
+				terminal || 'start-stackblitz'
+			}`;
 			return Response.redirect(target, 302);
 		}
 

--- a/worker-durable-objects/package.json
+++ b/worker-durable-objects/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"deploy": "wrangler publish index.js",
 		"dev": "wrangler dev index.js --local",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev index.js --local"
 	},
 	"devDependencies": {
 		"wrangler": "2.0.23"

--- a/worker-durable-objects/package.json
+++ b/worker-durable-objects/package.json
@@ -3,9 +3,10 @@
 	"version": "0.0.0",
 	"scripts": {
 		"deploy": "wrangler publish index.js",
-		"dev": "wrangler dev index.js --local"
+		"dev": "wrangler dev index.js --local",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"devDependencies": {
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }

--- a/worker-example-wordle/package.json
+++ b/worker-example-wordle/package.json
@@ -3,11 +3,12 @@
 	"version": "0.0.0",
 	"scripts": {
 		"dev": "wrangler dev --local",
-		"deploy": "wrangler publish"
+		"deploy": "wrangler publish",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.0.0",
 		"typescript": "^4.0.0",
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }

--- a/worker-router/package.json
+++ b/worker-router/package.json
@@ -3,12 +3,13 @@
 	"version": "0.0.0",
 	"scripts": {
 		"deploy": "wrangler publish index.js",
-		"dev": "wrangler dev index.js --local"
+		"dev": "wrangler dev index.js --local",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"dependencies": {
 		"itty-router": "^2.6.1"
 	},
 	"devDependencies": {
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }

--- a/worker-router/package.json
+++ b/worker-router/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"deploy": "wrangler publish index.js",
 		"dev": "wrangler dev index.js --local",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev index.js --local"
 	},
 	"dependencies": {
 		"itty-router": "^2.6.1"

--- a/worker-typescript/package.json
+++ b/worker-typescript/package.json
@@ -5,7 +5,7 @@
 		"deploy": "wrangler publish src/index.ts",
 		"dev": "wrangler dev src/index.ts --local",
 		"test": "uvu -r tsm test",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev src/index.ts --local"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.0.0",

--- a/worker-typescript/package.json
+++ b/worker-typescript/package.json
@@ -4,7 +4,8 @@
 	"scripts": {
 		"deploy": "wrangler publish src/index.ts",
 		"dev": "wrangler dev src/index.ts --local",
-		"test": "uvu -r tsm test"
+		"test": "uvu -r tsm test",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.0.0",
@@ -12,6 +13,6 @@
 		"service-worker-mock": "^2.0.5",
 		"tsm": "^2.2.1",
 		"uvu": "^0.5.3",
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }

--- a/worker-websocket-durable-objects/package.json
+++ b/worker-websocket-durable-objects/package.json
@@ -4,10 +4,11 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "^3.0.0",
 		"typescript": "^4.0.0",
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	},
 	"scripts": {
 		"start": "wrangler dev src/index.ts --local",
-		"deploy": "wrangler publish src/index.ts"
+		"deploy": "wrangler publish src/index.ts",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	}
 }

--- a/worker-websocket-durable-objects/package.json
+++ b/worker-websocket-durable-objects/package.json
@@ -9,6 +9,6 @@
 	"scripts": {
 		"start": "wrangler dev src/index.ts --local",
 		"deploy": "wrangler publish src/index.ts",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev src/index.ts --local"
 	}
 }

--- a/worker-websocket/package.json
+++ b/worker-websocket/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"deploy": "wrangler publish index.js",
 		"dev": "wrangler dev index.js --local",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev index.js --local"
 	},
 	"devDependencies": {
 		"wrangler": "2.0.23"

--- a/worker-websocket/package.json
+++ b/worker-websocket/package.json
@@ -3,9 +3,10 @@
 	"version": "0.0.0",
 	"scripts": {
 		"deploy": "wrangler publish index.js",
-		"dev": "wrangler dev index.js --local"
+		"dev": "wrangler dev index.js --local",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"devDependencies": {
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }

--- a/worker-worktop/package.json
+++ b/worker-worktop/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"deploy": "wrangler publish src/index.ts",
 		"dev": "wrangler dev src/index.ts --local",
-		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev src/index.ts --local"
 	},
 	"dependencies": {
 		"worktop": "0.8.0-next.14"

--- a/worker-worktop/package.json
+++ b/worker-worktop/package.json
@@ -3,12 +3,13 @@
 	"version": "0.0.0",
 	"scripts": {
 		"deploy": "wrangler publish src/index.ts",
-		"dev": "wrangler dev src/index.ts --local"
+		"dev": "wrangler dev src/index.ts --local",
+		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler dev --local"
 	},
 	"dependencies": {
 		"worktop": "0.8.0-next.14"
 	},
 	"devDependencies": {
-		"wrangler": "^2.0.0"
+		"wrangler": "2.0.23"
 	}
 }


### PR DESCRIPTION
1. wrangler@2.0.24 starts dev server with more ports open, which makes StackBlitz to open different port in the preview. Pinning StackBlitz supported templates to 2.0.23 until we figure out how to tell SB to open specific port for preview.
2. adding custom start command with `WRANGLER_SEND_METRICS=false` to allow SB to start without prompts