### PR TITLE
Update worker-rust template

### DIFF
--- a/worker-rust/Cargo.toml
+++ b/worker-rust/Cargo.toml
@@ -11,7 +11,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 cfg-if = "0.1.2"
-worker = "0.0.9"
+worker = "0.0.11"
 serde_json = "1.0.67"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/worker-rust/src/lib.rs
+++ b/worker-rust/src/lib.rs
@@ -9,7 +9,7 @@ fn log_request(req: &Request) {
         Date::now().to_string(),
         req.path(),
         req.cf().coordinates().unwrap_or_default(),
-        req.cf().region().unwrap_or("unknown region".into())
+        req.cf().region().unwrap_or_else(|| "unknown region".into())
     );
 }
 

--- a/worker-rust/wrangler.toml
+++ b/worker-rust/wrangler.toml
@@ -5,7 +5,7 @@ main = "build/worker/shim.mjs"
 compatibility_date = "2022-01-20"
 
 [vars]
-WORKERS_RS_VERSION = "0.0.9"
+WORKERS_RS_VERSION = "0.0.11"
 
 [build]
-command = "cargo install -q worker-build && worker-build --release"
+command = "cargo install -q worker-build --version 0.0.7 && worker-build --release"


### PR DESCRIPTION
Updates the Rust template to the latest release, fixes an issue where the build tool wasn't locked to the version of the library causing breakage in rare cases, and an annoying warning lint in the template.