### PR TITLE
Fix cache key generation for Webkit devices

### DIFF
--- a/examples/fast-google-fonts/fast-google-fonts.js
+++ b/examples/fast-google-fonts/fast-google-fonts.js
@@ -562,7 +562,7 @@ function getCacheKey(userAgent) {
 
 	// Detect Safari and Webview next
 	const webkitRegex = /\s+AppleWebKit\/(\d+)/gim;
-	match = webkitRegex.exec(userAgent.match);
+	match = webkitRegex.exec(userAgent);
 	if (match) {
 		return 'WebKit' + match[1] + os + mobile;
 	}


### PR DESCRIPTION
Worker was returning incorrect cached CSS for Webkit devices due to the cache key not being correctly generated.