### PR TITLE
Update wrangler.toml

### DIFF
--- a/worker-router/wrangler.toml
+++ b/worker-router/wrangler.toml
@@ -1,4 +1,3 @@
 name = "" # todo
-workers_dev = true
-
+main = "index.js"
 compatibility_date = "2022-05-03"


### PR DESCRIPTION
`workers_dev` defaults to true

main entrypoint, I did not see one defined in the package.json