### PR TITLE
Update wrangler.toml

### DIFF
--- a/worker-worktop/wrangler.toml
+++ b/worker-worktop/wrangler.toml
@@ -1,6 +1,5 @@
 name = "" # TODO
-workers_dev = true
-
+main = "./src/index.ts"
 compatibility_date = "2022-05-03"
 
 #


### PR DESCRIPTION
`workers_dev` is default true 

`main` explicitly setting the entrypoint 