### PR TITLE
PeerConnections are being GCed when they shouldn't

### DIFF
--- a/stream/webrtc/src/index.html
+++ b/stream/webrtc/src/index.html
@@ -20,7 +20,7 @@
 			const url = '<WEBRTC_URL_FROM_YOUR_LIVE_INPUT>';
 			const videoElement = document.getElementById('input-video');
 
-			const client = new WHIPClient(url, videoElement);
+			self.whipClient = new WHIPClient(url, videoElement);
 		</script>
 
 		<h4>Playing video using WHEP</h4>
@@ -33,7 +33,7 @@
 			const url = '<WEBRTC_PLAYBACK_URL_FROM_YOUR_LIVE_INPUT>';
 			const videoElement = document.getElementById('remote-video');
 
-			const client = new WHEPClient(url, videoElement);
+			self.whepClient = new WHEPClient(url, videoElement);
 		</script>
 	</body>
 </html>

--- a/stream/webrtc/src/whep.html
+++ b/stream/webrtc/src/whep.html
@@ -20,7 +20,7 @@
 			const url = '<WEBRTC_PLAYBACK_URL_FROM_YOUR_LIVE_INPUT>';
 			const videoElement = document.getElementById('remote-video');
 
-			const client = new WHEPClient(url, videoElement);
+			self.client = new WHEPClient(url, videoElement);
 		</script>
 	</body>
 </html>

--- a/stream/webrtc/src/whip.html
+++ b/stream/webrtc/src/whip.html
@@ -20,7 +20,7 @@
 			const url = '<WEBRTC_URL_FROM_YOUR_LIVE_INPUT>';
 			const videoElement = document.getElementById('input-video');
 
-			const client = new WHIPClient(url, videoElement);
+			self.client = new WHIPClient(url, videoElement);
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Firefox is garbage collecting active PeerConnections when there is no reference to them from a root object. Fixes #128