### PR TITLE
Fix import of worker in typescript template

### DIFF
--- a/worker-typescript/test/index.test.ts
+++ b/worker-typescript/test/index.test.ts
@@ -1,4 +1,4 @@
-import { worker } from '../src/index';
+import worker from '../src/index';
 
 test('GET /', async () => {
 	const req = new Request('http://falcon', { method: 'GET' });


### PR DESCRIPTION
A while ago, typescript template switched to default export (https://github.com/cloudflare/templates/pull/126). But it seems like its still using named import in the test file which results in failure. This PR fixes it.