### PR TITLE
[Stream + Stripe] Pin Wrangler to 2.0.23

### DIFF
--- a/stream/auth/stripe/package.json
+++ b/stream/auth/stripe/package.json
@@ -6,7 +6,7 @@
 		"start-stackblitz": "WRANGLER_SEND_METRICS=false wrangler pages dev --local --node-compat ./src"
 	},
 	"devDependencies": {
-		"wrangler": "^2.1.13"
+		"wrangler": "2.0.23"
 	},
 	"dependencies": {
 		"stripe": "^10.15.0"


### PR DESCRIPTION
Pin to an older version of Wrangler while we sort out compatibility issues with Stackblitz and more recent version of Wrangler.

Using any version of Wrangler higher than 2.0.23 breaks this example in Stackblitz. Not immediately clear what changed in 2.0.24:

https://github.com/cloudflare/wrangler2/releases/tag/wrangler%402.0.24