### PR TITLE
Add itty-router-openapi template

### DIFF
--- a/worker-openapi/.gitignore
+++ b/worker-openapi/.gitignore
@@ -1,0 +1,2 @@
+wrangler-local-state
+dist

--- a/worker-openapi/README.md
+++ b/worker-openapi/README.md
@@ -4,6 +4,8 @@
 
 This template demonstrates using the [`itty-router-openapi`](https://github.com/cloudflare/itty-router-openapi) package to add openapi 3 schema generation and validation.
 
+You can try this template in your browser [here](https://worker-openapi-example.radar.cloudflare.com/docs)!
+
 ## Setup
 
 To create a `my-project` directory using this template, run:

--- a/worker-openapi/README.md
+++ b/worker-openapi/README.md
@@ -24,7 +24,6 @@ Run `wrangler dev` and head to `/docs` our `/redocs` with your browser.
 
 You'll be greeted with an OpenAPI page that you can use to test and call your endpoints.
 
-
 ## Deploy
 
 Once you are ready, you can publish your code by running the following command:

--- a/worker-openapi/README.md
+++ b/worker-openapi/README.md
@@ -1,0 +1,34 @@
+## Template: worker-openapi
+
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-openapi)
+
+This template demonstrates using the [`itty-router-openapi`](https://github.com/cloudflare/itty-router-openapi) package to add openapi 3 schema generation and validation.
+
+## Setup
+
+To create a `my-project` directory using this template, run:
+
+```sh
+$ npm init cloudflare my-project worker-openapi
+# or
+$ yarn create cloudflare my-project worker-openapi
+# or
+$ pnpm create cloudflare my-project worker-openapi
+```
+
+> **Note:** Each command invokes [`create-cloudflare`](https://www.npmjs.com/package/create-cloudflare) for project creation.
+
+## Local development
+
+Run `wrangler dev` and head to `/docs` our `/redocs` with your browser.
+
+You'll be greeted with an OpenAPI page that you can use to test and call your endpoints.
+
+
+## Deploy
+
+Once you are ready, you can publish your code by running the following command:
+
+```sh
+$ wrangler publish
+```

--- a/worker-openapi/package.json
+++ b/worker-openapi/package.json
@@ -15,6 +15,6 @@
 		"wrangler": "^2.4.4"
 	},
 	"dependencies": {
-		"@cloudflare/itty-router-openapi": "^0.0.8"
+		"@cloudflare/itty-router-openapi": "^0.0.10"
 	}
 }

--- a/worker-openapi/package.json
+++ b/worker-openapi/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "worker-openapi",
+	"version": "1.0.0",
+	"description": "Cloudflare workers template with OpenAPI 3 schema generation and validation",
+	"main": "src/index.ts",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "MIT",
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20221111.1",
+		"@types/service-worker-mock": "^2.0.1",
+		"wrangler": "^2.4.4"
+	},
+	"dependencies": {
+		"@cloudflare/itty-router-openapi": "^0.0.8"
+	}
+}

--- a/worker-openapi/src/index.ts
+++ b/worker-openapi/src/index.ts
@@ -7,6 +7,9 @@ router.post('/api/tasks/', TaskCreate);
 router.get('/api/tasks/:taskSlug/', TaskFetch);
 router.delete('/api/tasks/:taskSlug/', TaskDelete);
 
+// Redirect root request to the /docs page
+router.original.get('/', (request) => Response.redirect(`${request.url}docs`, 302))
+
 // 404 for everything else
 router.all('*', () => new Response('Not Found.', { status: 404 }));
 

--- a/worker-openapi/src/index.ts
+++ b/worker-openapi/src/index.ts
@@ -2,12 +2,12 @@ import { OpenAPIRouter } from '@cloudflare/itty-router-openapi';
 import { TaskCreate, TaskDelete, TaskFetch, TaskList } from './tasks';
 
 const router = OpenAPIRouter({
-  schema: {
-    info: {
-      title: 'Worker OpenAPI Example',
-      version: '1.0',
-    }
-  }
+	schema: {
+		info: {
+			title: 'Worker OpenAPI Example',
+			version: '1.0',
+		},
+	},
 });
 
 router.get('/api/tasks/', TaskList);
@@ -16,7 +16,7 @@ router.get('/api/tasks/:taskSlug/', TaskFetch);
 router.delete('/api/tasks/:taskSlug/', TaskDelete);
 
 // Redirect root request to the /docs page
-router.original.get('/', (request) => Response.redirect(`${request.url}docs`, 302))
+router.original.get('/', request => Response.redirect(`${request.url}docs`, 302));
 
 // 404 for everything else
 router.all('*', () => new Response('Not Found.', { status: 404 }));

--- a/worker-openapi/src/index.ts
+++ b/worker-openapi/src/index.ts
@@ -1,0 +1,15 @@
+import {OpenAPIRouter} from '@cloudflare/itty-router-openapi'
+import {TaskCreate, TaskDelete, TaskFetch, TaskList} from './tasks'
+
+const router = OpenAPIRouter()
+router.get('/api/tasks/', TaskList)
+router.post('/api/tasks/', TaskCreate)
+router.get('/api/tasks/:taskSlug/', TaskFetch)
+router.delete('/api/tasks/:taskSlug/', TaskDelete)
+
+// 404 for everything else
+router.all('*', () => new Response('Not Found.', {status: 404}))
+
+export default {
+		fetch: router.handle
+}

--- a/worker-openapi/src/index.ts
+++ b/worker-openapi/src/index.ts
@@ -1,7 +1,15 @@
 import { OpenAPIRouter } from '@cloudflare/itty-router-openapi';
 import { TaskCreate, TaskDelete, TaskFetch, TaskList } from './tasks';
 
-const router = OpenAPIRouter();
+const router = OpenAPIRouter({
+  schema: {
+    info: {
+      title: 'Worker OpenAPI Example',
+      version: '1.0',
+    }
+  }
+});
+
 router.get('/api/tasks/', TaskList);
 router.post('/api/tasks/', TaskCreate);
 router.get('/api/tasks/:taskSlug/', TaskFetch);

--- a/worker-openapi/src/index.ts
+++ b/worker-openapi/src/index.ts
@@ -1,15 +1,15 @@
-import {OpenAPIRouter} from '@cloudflare/itty-router-openapi'
-import {TaskCreate, TaskDelete, TaskFetch, TaskList} from './tasks'
+import { OpenAPIRouter } from '@cloudflare/itty-router-openapi';
+import { TaskCreate, TaskDelete, TaskFetch, TaskList } from './tasks';
 
-const router = OpenAPIRouter()
-router.get('/api/tasks/', TaskList)
-router.post('/api/tasks/', TaskCreate)
-router.get('/api/tasks/:taskSlug/', TaskFetch)
-router.delete('/api/tasks/:taskSlug/', TaskDelete)
+const router = OpenAPIRouter();
+router.get('/api/tasks/', TaskList);
+router.post('/api/tasks/', TaskCreate);
+router.get('/api/tasks/:taskSlug/', TaskFetch);
+router.delete('/api/tasks/:taskSlug/', TaskDelete);
 
 // 404 for everything else
-router.all('*', () => new Response('Not Found.', {status: 404}))
+router.all('*', () => new Response('Not Found.', { status: 404 }));
 
 export default {
-		fetch: router.handle
-}
+	fetch: router.handle,
+};

--- a/worker-openapi/src/tasks.ts
+++ b/worker-openapi/src/tasks.ts
@@ -1,0 +1,161 @@
+import {Bool, DateOnly, Int, OpenAPIRoute, Path, Query, Str} from '@cloudflare/itty-router-openapi'
+
+const Task = {
+		name: new Str({example: 'lorem'}),
+		slug: String,
+		description: new Str({required: false}),
+		completed: Boolean,
+		due_date: new DateOnly()
+}
+
+export class TaskFetch extends OpenAPIRoute {
+		static schema = {
+				tags: ['Tasks'],
+				summary: 'Get a single Task by slug',
+				parameters: {
+						taskSlug: Path(Str, {
+								description: 'Task slug'
+						}),
+				},
+				responses: {
+						'200': {
+								schema: {
+										metaData: {},
+										task: Task,
+								},
+						},
+				},
+		}
+
+		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+				// Retrieve the validated slug
+				const {taskSlug} = data
+
+				// Actually fetch a task using the taskSlug
+
+				return {
+						metaData: {meta: 'data'},
+						task: {
+								name: 'my task',
+								slug: taskSlug,
+								description: 'this needs to be done',
+								completed: false,
+								due_date: new Date().toISOString().slice(0, 10)
+						},
+				}
+		}
+}
+
+export class TaskCreate extends OpenAPIRoute {
+		static schema = {
+				tags: ['Tasks'],
+				summary: 'Create a new Task',
+				requestBody: Task,
+				responses: {
+						'200': {
+								schema: {
+										task: Task,
+								},
+						},
+				},
+		}
+
+		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+				// Retrieve the validated request body
+				const {body} = data
+
+				// Actually insert the task
+
+				// return the new task
+				return {
+						metaData: {meta: 'data'},
+						task: {
+								name: body.name,
+								slug: body.slug,
+								description: body.description,
+								completed: body.completed,
+								due_date: body.due_date
+						},
+				}
+		}
+}
+
+
+export class TaskList extends OpenAPIRoute {
+		static schema = {
+				tags: ['Tasks'],
+				summary: 'List Tasks',
+				parameters: {
+						page: Query(Int, {
+								description: 'Page number',
+								default: 0
+						}),
+						isCompleted: Query(Bool, {
+								description: 'Filter by completed flag',
+								required: false,
+						}),
+				},
+				responses: {
+						'200': {
+								schema: {
+										tasks: [Task],
+								},
+						},
+				},
+		}
+
+		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+				// Retrieve the validated parameters
+				const {page, isCompleted} = data
+
+				return {
+						metaData: {page: page, isCompleted: isCompleted},
+						tasks: [
+								{
+										name: "Clean my room",
+										slug: "clean-room",
+										description: null,
+										completed: false,
+										due_date: "2025-01-05"
+								},
+								{
+										name: "Build something awesome with Cloudflare Workers",
+										slug: "cloudflare-workers",
+										description: "Lorem Ipsum",
+										completed: true,
+										due_date: "2022-12-24"
+								},
+						],
+				}
+		}
+}
+
+export class TaskDelete extends OpenAPIRoute {
+		static schema = {
+				tags: ['Tasks'],
+				summary: 'Delete a Task',
+				parameters: {
+						taskSlug: Path(Str, {
+								description: 'Task slug'
+						}),
+				},
+				responses: {
+						'200': {
+								schema: {
+										metaData: {},
+										success: Boolean,
+								},
+						},
+				},
+		}
+
+		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+				// Retrieve the validated slug
+				const {taskSlug} = data
+
+				return {
+						metaData: {taskSlug: taskSlug},
+						success: true,
+				}
+		}
+}

--- a/worker-openapi/src/tasks.ts
+++ b/worker-openapi/src/tasks.ts
@@ -1,161 +1,168 @@
-import {Bool, DateOnly, Int, OpenAPIRoute, Path, Query, Str} from '@cloudflare/itty-router-openapi'
+import {
+	Bool,
+	DateOnly,
+	Int,
+	OpenAPIRoute,
+	Path,
+	Query,
+	Str,
+} from '@cloudflare/itty-router-openapi';
 
 const Task = {
-		name: new Str({example: 'lorem'}),
-		slug: String,
-		description: new Str({required: false}),
-		completed: Boolean,
-		due_date: new DateOnly()
-}
+	name: new Str({ example: 'lorem' }),
+	slug: String,
+	description: new Str({ required: false }),
+	completed: Boolean,
+	due_date: new DateOnly(),
+};
 
 export class TaskFetch extends OpenAPIRoute {
-		static schema = {
-				tags: ['Tasks'],
-				summary: 'Get a single Task by slug',
-				parameters: {
-						taskSlug: Path(Str, {
-								description: 'Task slug'
-						}),
+	static schema = {
+		tags: ['Tasks'],
+		summary: 'Get a single Task by slug',
+		parameters: {
+			taskSlug: Path(Str, {
+				description: 'Task slug',
+			}),
+		},
+		responses: {
+			'200': {
+				schema: {
+					metaData: {},
+					task: Task,
 				},
-				responses: {
-						'200': {
-								schema: {
-										metaData: {},
-										task: Task,
-								},
-						},
-				},
-		}
+			},
+		},
+	};
 
-		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
-				// Retrieve the validated slug
-				const {taskSlug} = data
+	async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+		// Retrieve the validated slug
+		const { taskSlug } = data;
 
-				// Actually fetch a task using the taskSlug
+		// Actually fetch a task using the taskSlug
 
-				return {
-						metaData: {meta: 'data'},
-						task: {
-								name: 'my task',
-								slug: taskSlug,
-								description: 'this needs to be done',
-								completed: false,
-								due_date: new Date().toISOString().slice(0, 10)
-						},
-				}
-		}
+		return {
+			metaData: { meta: 'data' },
+			task: {
+				name: 'my task',
+				slug: taskSlug,
+				description: 'this needs to be done',
+				completed: false,
+				due_date: new Date().toISOString().slice(0, 10),
+			},
+		};
+	}
 }
 
 export class TaskCreate extends OpenAPIRoute {
-		static schema = {
-				tags: ['Tasks'],
-				summary: 'Create a new Task',
-				requestBody: Task,
-				responses: {
-						'200': {
-								schema: {
-										task: Task,
-								},
-						},
+	static schema = {
+		tags: ['Tasks'],
+		summary: 'Create a new Task',
+		requestBody: Task,
+		responses: {
+			'200': {
+				schema: {
+					task: Task,
 				},
-		}
+			},
+		},
+	};
 
-		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
-				// Retrieve the validated request body
-				const {body} = data
+	async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+		// Retrieve the validated request body
+		const { body } = data;
 
-				// Actually insert the task
+		// Actually insert the task
 
-				// return the new task
-				return {
-						metaData: {meta: 'data'},
-						task: {
-								name: body.name,
-								slug: body.slug,
-								description: body.description,
-								completed: body.completed,
-								due_date: body.due_date
-						},
-				}
-		}
+		// return the new task
+		return {
+			metaData: { meta: 'data' },
+			task: {
+				name: body.name,
+				slug: body.slug,
+				description: body.description,
+				completed: body.completed,
+				due_date: body.due_date,
+			},
+		};
+	}
 }
 
-
 export class TaskList extends OpenAPIRoute {
-		static schema = {
-				tags: ['Tasks'],
-				summary: 'List Tasks',
-				parameters: {
-						page: Query(Int, {
-								description: 'Page number',
-								default: 0
-						}),
-						isCompleted: Query(Bool, {
-								description: 'Filter by completed flag',
-								required: false,
-						}),
+	static schema = {
+		tags: ['Tasks'],
+		summary: 'List Tasks',
+		parameters: {
+			page: Query(Int, {
+				description: 'Page number',
+				default: 0,
+			}),
+			isCompleted: Query(Bool, {
+				description: 'Filter by completed flag',
+				required: false,
+			}),
+		},
+		responses: {
+			'200': {
+				schema: {
+					tasks: [Task],
 				},
-				responses: {
-						'200': {
-								schema: {
-										tasks: [Task],
-								},
-						},
+			},
+		},
+	};
+
+	async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+		// Retrieve the validated parameters
+		const { page, isCompleted } = data;
+
+		return {
+			metaData: { page: page, isCompleted: isCompleted },
+			tasks: [
+				{
+					name: 'Clean my room',
+					slug: 'clean-room',
+					description: null,
+					completed: false,
+					due_date: '2025-01-05',
 				},
-		}
-
-		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
-				// Retrieve the validated parameters
-				const {page, isCompleted} = data
-
-				return {
-						metaData: {page: page, isCompleted: isCompleted},
-						tasks: [
-								{
-										name: "Clean my room",
-										slug: "clean-room",
-										description: null,
-										completed: false,
-										due_date: "2025-01-05"
-								},
-								{
-										name: "Build something awesome with Cloudflare Workers",
-										slug: "cloudflare-workers",
-										description: "Lorem Ipsum",
-										completed: true,
-										due_date: "2022-12-24"
-								},
-						],
-				}
-		}
+				{
+					name: 'Build something awesome with Cloudflare Workers',
+					slug: 'cloudflare-workers',
+					description: 'Lorem Ipsum',
+					completed: true,
+					due_date: '2022-12-24',
+				},
+			],
+		};
+	}
 }
 
 export class TaskDelete extends OpenAPIRoute {
-		static schema = {
-				tags: ['Tasks'],
-				summary: 'Delete a Task',
-				parameters: {
-						taskSlug: Path(Str, {
-								description: 'Task slug'
-						}),
+	static schema = {
+		tags: ['Tasks'],
+		summary: 'Delete a Task',
+		parameters: {
+			taskSlug: Path(Str, {
+				description: 'Task slug',
+			}),
+		},
+		responses: {
+			'200': {
+				schema: {
+					metaData: {},
+					success: Boolean,
 				},
-				responses: {
-						'200': {
-								schema: {
-										metaData: {},
-										success: Boolean,
-								},
-						},
-				},
-		}
+			},
+		},
+	};
 
-		async handle(request: Request, env: any, context: any, data: Record<string, any>) {
-				// Retrieve the validated slug
-				const {taskSlug} = data
+	async handle(request: Request, env: any, context: any, data: Record<string, any>) {
+		// Retrieve the validated slug
+		const { taskSlug } = data;
 
-				return {
-						metaData: {taskSlug: taskSlug},
-						success: true,
-				}
-		}
+		return {
+			metaData: { taskSlug: taskSlug },
+			success: true,
+		};
+	}
 }

--- a/worker-openapi/tsconfig.json
+++ b/worker-openapi/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        //    "alwaysStrict": true,
-            "strict": false,
-        "types": ["@cloudflare/workers-types", "@types/service-worker-mock"],
-        "allowJs": true
-    },
-    "include": ["src"],
+	"compilerOptions": {
+		"target": "esnext",
+		//    "alwaysStrict": true,
+		"strict": false,
+		"types": ["@cloudflare/workers-types", "@types/service-worker-mock"],
+		"allowJs": true
+	},
+	"include": ["src"]
 }

--- a/worker-openapi/tsconfig.json
+++ b/worker-openapi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        //    "alwaysStrict": true,
+            "strict": false,
+        "types": ["@cloudflare/workers-types", "@types/service-worker-mock"],
+        "allowJs": true
+    },
+    "include": ["src"],
+}

--- a/worker-openapi/wrangler.toml
+++ b/worker-openapi/wrangler.toml
@@ -1,0 +1,3 @@
+name = "worker-openapi"
+main = "src/index.ts"
+compatibility_date = "2022-11-28"


### PR DESCRIPTION
Adds a new worker example on how to use [itty-router-openapi](https://github.com/cloudflare/itty-router-openapi) for schema generation and validation