### PR TITLE
Fix worker-build on Windows

### DIFF
--- a/worker-rust/wrangler.toml
+++ b/worker-rust/wrangler.toml
@@ -6,4 +6,4 @@ compatibility_date = "2022-01-20"
 WORKERS_RS_VERSION = "0.0.11"
 
 [build]
-command = "cargo install -q worker-build --version 0.0.7 && worker-build --release"
+command = "cargo install -q worker-build --version 0.0.8 && worker-build --release"


### PR DESCRIPTION
Update the worker-build version inside the `wrangler.toml` to address this issue: https://github.com/cloudflare/workers-rs/issues/222#issuecomment-1314353798