### PR TITLE
Mark repo as archived and redirect to Workers SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Cloudflare Workers – Templates & Examples
 
+:stop_sign: This repository is the old home for Cloudflare Workers templates and examples. This repo is archived and is no longer maintained. 
+
+Templates and examples for Cloudflare Workers are now maintained in the [Workers SDK repository](https://github.com/cloudflare/workers-sdk).
+
+---
+
+<details>
+<summary>Legacy Documentation</summary>
+
 Cloudflare Workers make it possible to write Javascript which runs on Cloudflare’s network around the world. Using Workers you can build services which run exceptionally close to your users. You can also intercept any request, which would ordinarily travel through Cloudflare to your origin, and modify it in any way you need. Workers can make requests to arbitrary resources on the Internet, perform cryptography using the WebCrypto API, or do nearly anything you'd typically configure a CDN to accomplish.
 
 This repository contains a collection of starter templates and examples of how Workers can be used to accomplish common tasks. **You are welcome to use, modify, and extend this code!** If you have an additional example you think would be valuable, please submit a pull request.
@@ -58,3 +67,5 @@ If adding a new template, please pick a unique name and aim for simplicity and c
 ## License
 
 MIT
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloudflare Workers – Templates & Examples
 
-:stop_sign: This repository is the old home for Cloudflare Workers templates and examples. This repo is archived and is no longer maintained. 
+:stop_sign: This repository is the old home for Cloudflare Workers templates and examples. This repo is archived and is no longer maintained.
 
 Templates and examples for Cloudflare Workers are now maintained in the [Workers SDK repository](https://github.com/cloudflare/workers-sdk).
 


### PR DESCRIPTION
This PR adds a note to the README that the repo is now archived and that templates are being maintained in the workers-sdk monorepo. Legacy documentation is moved into an accordion/collapsed section.