### PR TITLE
fix: Restore node_modules after generating npm lockfiles

### DIFF
--- a/cli/src/npm.ts
+++ b/cli/src/npm.ts
@@ -30,12 +30,15 @@ export async function generateNpmLockfiles(): Promise<void> {
     }
 
     await fs.rm("./package-lock.json", { force: true });
-    await fs.rm("./node_modules", { force: true, recursive: true });
+    // Rename node_modules to prevent npm from using it's contents in the lockfile
+    await fs.move("./node_modules", "./._node_modules");
 
     await $({
       verbose: true,
       stdio: "inherit",
     })`npm install --no-audit --progress=false --package-lock-only`;
+
+    await fs.move("./._node_modules", "./node_modules");
   }
 
   await config.save();


### PR DESCRIPTION
# Description

Previously thought we could avoid removing node_modules at all, but it turns out npm resolves things differently if we leave node_modules intact before running `npm install --no-audit --progress=false --package-lock-only`

To make the script faster, this renames node_modules rather than removing it entirely.

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [ ] "cloudflare" section of package.json is populated
  - [ ] template preview image uploaded to Images
  - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview

## Example package.json

```json
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "icon_urls": [
    "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/c6fc5da3-1e0a-4608-b2f1-9628577ec800/public",
    "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/5ca0ca32-e897-4699-d4c1-6b680512f000/public"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
