### PR TITLE
chore: update target branch for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directories:
       - "**/*"
+    target-branch: "staging"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# Description

Update dependabot so it targets the `staging` branch with updates instead of `main`

