### PR TITLE
fix: vite react template package.json and add package.json linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ The following selections do not need to be completed if this PR only contains ch
   - [ ] "cloudflare" section of package.json is populated
   - [ ] template preview image uploaded to Images
   - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
+  - [ ] package.json contains a `deploy` command
 
 ## Example package.json
 

--- a/openauth-template/package-lock.json
+++ b/openauth-template/package-lock.json
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/openauth-template/package.json
+++ b/openauth-template/package.json
@@ -8,6 +8,7 @@
       "D1",
       "KV"
     ],
+    "categories": [],
     "icon_urls": [
       "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/5ca0ca32-e897-4699-d4c1-6b680512f000/public"
     ],

--- a/templates.json
+++ b/templates.json
@@ -10,7 +10,7 @@
       "package_json_hash": "60336ddae91c182f025794f86cbb5613167afd74"
     },
     "openauth-template": {
-      "package_json_hash": "c579e563572484824e2b4bd59a1a4fa165506fc7"
+      "package_json_hash": "203f2448e457117f20d50628520e38946c9184bf"
     },
     "react-router-starter-template": {
       "package_json_hash": "6d76cb58b217ab86d278bde549a9b225ea56a90c"
@@ -34,7 +34,7 @@
       "package_json_hash": "7ddf38103d3833ee9790d639958525cc045251e3"
     },
     "vite-react-template": {
-      "package_json_hash": "b54da71f57f765e9bc78c2d023c0380bec6a9e84"
+      "package_json_hash": "cbe6857375c9c7ca884434f76fad89a2ef24c0de"
     }
   }
 }

--- a/vite-react-template/package-lock.json
+++ b/vite-react-template/package-lock.json
@@ -1065,13 +1065,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.6.tgz",
-      "integrity": "sha512-+0TjwR1eAUdZtvv/ir1mGX+v0tUoR3VEPB8Up0LLJC+whRW0GgBBtpbOkg/a/U4Dxa6l5a3l9AJ1aWIQVyoWJA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.11.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2271,9 +2271,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.102",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+      "version": "1.5.103",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.103.tgz",
+      "integrity": "sha512-P6+XzIkfndgsrjROJWfSvVEgNHtPgbhVyTkwLjUM2HU/h7pZRORgaTlHqfAikqxKmdJMLW8fftrdGWbd/Ds0FA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3070,6 +3070,28 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/minimatch": {
@@ -4519,9 +4541,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/vite-react-template/package.json
+++ b/vite-react-template/package.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "build": "tsc -b && vite build",
+    "deploy": "npm run build && wrangler deploy",
     "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
# Description

Adds linting for package.json files to our CI checks. The `check:ci` command ensures there is a deploy script and the cloudflare object is configured.

## To test
If you want to test out the functionality, you can 

1. Clone the repo and checkout the PR branch
2. `pnpm install` at the top level
3. run `pnpm check:ci` at the top level. The checks should pass.
4. Go into a package.json of one of the templates and delete some keys out of the cloudflare object and delete the `deploy` script. 
5. Run `pnpm check:ci` at the top level again and it should fail

