### PR TITLE
Remove hardcoded DB names in favor of DB bindings

### DIFF
--- a/d1-template/package.json
+++ b/d1-template/package.json
@@ -26,8 +26,8 @@
     "check": "tsc && wrangler --experimental-json-config deploy --dry-run",
     "deploy": "wrangler --experimental-json-config deploy",
     "dev": "wrangler --experimental-json-config dev",
-    "predeploy": "wrangler --experimental-json-config d1 migrations apply d1-template-database --remote",
-    "seedLocalD1": "wrangler --experimental-json-config d1 migrations apply d1-template-database --local",
+    "predeploy": "wrangler --experimental-json-config d1 migrations apply DB --remote",
+    "seedLocalD1": "wrangler --experimental-json-config d1 migrations apply DB --local",
     "types": "wrangler --experimental-json-config types"
   }
 }

--- a/openauth-template/package.json
+++ b/openauth-template/package.json
@@ -27,7 +27,7 @@
     "check": "tsc && wrangler --experimental-json-config deploy --dry-run",
     "deploy": "wrangler --experimental-json-config deploy",
     "dev": "wrangler --experimental-json-config dev",
-    "predeploy": "wrangler --experimental-json-config d1 migrations apply openauth-template-auth-db --remote",
+    "predeploy": "wrangler --experimental-json-config d1 migrations apply AUTH_DB --remote",
     "types": "wrangler --experimental-json-config types"
   }
 }


### PR DESCRIPTION
In order for migrations to run successfully, the migration command should use the D1 binding name, since the DB name can/will change when the template is cloned by another user.
