### PR TITLE
Add Deploy To Workers button for Next.js Starter

### DIFF
--- a/next-starter-template/README.md
+++ b/next-starter-template/README.md
@@ -1,8 +1,8 @@
 # Next.js Framework Starter
 
-<!-- dash-content-start -->
-
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/staging/next-starter-template)
+
+<!-- dash-content-start -->
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). It's deployed on Cloudflare Workers as a [static website](https://developers.cloudflare.com/workers/static-assets/).
 

--- a/next-starter-template/README.md
+++ b/next-starter-template/README.md
@@ -2,6 +2,8 @@
 
 <!-- dash-content-start -->
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/staging/next-starter-template)
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). It's deployed on Cloudflare Workers as a [static website](https://developers.cloudflare.com/workers/static-assets/).
 
 <!-- dash-content-end -->


### PR DESCRIPTION
# Description

Adding the "Deploy To Workers" button to the nextjs-starter-template

# Checklist

- Template Metadata
  - [x] "cloudflare" section of package.json is populated
  - [x] template preview image uploaded to Images
  - [x] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [x] package.json contains a `deploy` command
