### PR TITLE
fix: provision d1 db for template preview

### DIFF
--- a/d1-starter-sessions-api-template/wrangler.jsonc
+++ b/d1-starter-sessions-api-template/wrangler.jsonc
@@ -23,7 +23,7 @@
     {
       "binding": "DB01",
       "database_name": "d1-starter-sessions-api",
-      "database_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "database_id": "3690f364-3425-4fab-8eb7-c74c5717578a",
     },
   ],
 }

--- a/mysql-hyperdrive-template/wrangler.json
+++ b/mysql-hyperdrive-template/wrangler.json
@@ -10,7 +10,7 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "09f05ae3c14d47eebff77160d8a38d19",
+      "id": "7668c461af3c47969772c19cbd988391",
       "localConnectionString": "<ENTER_LOCAL_CONNECTION_STRING_FOR_LOCAL_DEVELOPMENT>"
     }
   ],

--- a/postgres-hyperdrive-template/wrangler.jsonc
+++ b/postgres-hyperdrive-template/wrangler.jsonc
@@ -14,7 +14,7 @@
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",
-      "id": "<YOUR_HYPERDRIVE_ID>",
+      "id": "5bbc3c9c39ec4641b7f94344675acd2d",
       "localConnectionString": "<ENTER_LOCAL_CONNECTION_STRING_FOR_LOCAL_DEVELOPMENT>",
     },
   ],


### PR DESCRIPTION
# Description

Adds d1 database for template preview

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [ ] "cloudflare" section of package.json is populated
  - [ ] template preview image uploaded to Images
  - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [ ] package.json contains a `deploy` command

## Example package.json

```json
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "icon_urls": [
    "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/c6fc5da3-1e0a-4608-b2f1-9628577ec800/public",
    "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/5ca0ca32-e897-4699-d4c1-6b680512f000/public"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
