### PR TITLE
Fix missed areas during rename to add template suffix

### DIFF
--- a/d1-starter-sessions-api-template/README.md
+++ b/d1-starter-sessions-api-template/README.md
@@ -1,6 +1,6 @@
 # d1-starter-sessions-api
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/d1-starter-sessions-api)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/d1-starter-sessions-api-template)
 
 <!-- dash-content-start -->
 

--- a/d1-starter-sessions-api-template/public/index.html
+++ b/d1-starter-sessions-api-template/public/index.html
@@ -260,7 +260,7 @@
 
             <small
               >(<a
-                href="https://github.com/cloudflare/templates/tree/staging/d1-starter-sessions-api"
+                href="https://github.com/cloudflare/templates/tree/main/d1-starter-sessions-api-template"
                 target="_blank"
                 >Demo source code</a
               >)</small


### PR DESCRIPTION
Missed renaming d1-starter-sessions-api to d1-starter-sessions-api-template in links.