### PR TITLE
Undo acceptance of empty string for preview image

### DIFF
--- a/cli/src/lint.ts
+++ b/cli/src/lint.ts
@@ -321,10 +321,7 @@ function lintPackageJson(
       problems.push('"cloudflare.icon_urls" must be an array');
     }
     //Ensure either a preview image url is set OR one is intentionally not set by forcing an empty string specification
-    if (
-      !pkg.cloudflare.preview_image_url &&
-      pkg.cloudflare.preview_image_url !== ""
-    ) {
+    if (!pkg.cloudflare.preview_image_url) {
       problems.push('"cloudflare.preview_image_url" must be defined');
     }
   }

--- a/react-router-postgres-ssr-template/package.json
+++ b/react-router-postgres-ssr-template/package.json
@@ -15,7 +15,7 @@
     ],
     "docs_url": "https://developers.cloudflare.com/workers/frameworks/framework-guides/react-router/",
     "icon_urls": [],
-    "preview_image_url": "",
+    "preview_image_url": "https://api.cloudflare.com/client/v4/accounts/8ae4e74afb48193eb3d72bbfcc499b70/images/v1/8db618d7-0c0e-4ab5-f6f5-721e45b80c00",
     "dash": true
   },
   "dependencies": {

--- a/templates.json
+++ b/templates.json
@@ -49,7 +49,7 @@
       "package_json_hash": "bb887f2b248739a425023bcd9527544c79c695fc"
     },
     "react-router-postgres-ssr-template": {
-      "package_json_hash": "2f8b0c981cd78086f024168a5bec2d1aed8abf15"
+      "package_json_hash": "9993bf05102086909aa7e65913e1970da52ae8be"
     },
     "react-postgres-fullstack-template": {
       "package_json_hash": "7d69e15de279535b15fa1c0f84129038ccae1870"


### PR DESCRIPTION
# Description

Turns out, even though dash allows empty strings for preview images, the integrations platform does not.

1. Removes linter acceptance of empty strings for preview images
2. Adds an image link for the default image to one of the newest templates that desired to fall back on the default image