### PR TITLE
[WP-1570] Set jsoncparser to use jsoncwriter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "12.1.0",
     "commander": "12.1.0",
+    "comment-json": "4.2.5",
     "jsonc-parser": "3.3.1",
     "toml": "3.0.0",
     "zod": "3.24.2",

--- a/cli/src/lint.ts
+++ b/cli/src/lint.ts
@@ -7,6 +7,7 @@ import {
   readToml,
   Template,
   writeJson,
+  writeJsonC,
 } from "./util";
 
 export type LintConfig = {
@@ -119,7 +120,7 @@ function lintWranglerJsonC(
     wrangler.observability = { enabled: true };
     wrangler.upload_source_maps = true;
     wrangler.name = template.name;
-    writeJson(filePath, wrangler);
+    writeJsonC(filePath, wrangler);
     return [];
   }
   const problems = [];

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -1,4 +1,4 @@
-import { parse } from "jsonc-parser";
+import { parse, stringify } from "comment-json";
 import fs from "node:fs";
 import path from "node:path";
 import toml from "toml";
@@ -72,6 +72,10 @@ export function readToml(filePath: string): unknown {
 
 export function readJsonC(filePath: string): unknown {
   return parse(fs.readFileSync(filePath, { encoding: "utf-8" }));
+}
+
+export function writeJsonC(filePath: string, object: unknown) {
+  fs.writeFileSync(filePath, stringify(object, undefined, 2) + "\n");
 }
 
 export function readJson(filePath: string): unknown {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       commander:
         specifier: 12.1.0
         version: 12.1.0
+      comment-json:
+        specifier: 4.2.5
+        version: 4.2.5
       jsonc-parser:
         specifier: 3.3.1
         version: 3.3.1
@@ -4040,6 +4043,9 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -4361,6 +4367,10 @@ packages:
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  comment-json@4.2.5:
+    resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
     engines: {node: '>= 6'}
 
   common-ancestor-path@1.0.1:
@@ -4902,6 +4912,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -5301,6 +5316,10 @@ packages:
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-own-prop@2.0.0:
+    resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
@@ -7187,6 +7206,10 @@ packages:
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
 
   require-like@0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
@@ -12502,6 +12525,8 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
+  array-timsort@1.0.3: {}
+
   array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
@@ -12951,6 +12976,14 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
+
+  comment-json@4.2.5:
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+      has-own-prop: 2.0.0
+      repeat-string: 1.6.1
 
   common-ancestor-path@1.0.1: {}
 
@@ -13837,6 +13870,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -14353,6 +14388,8 @@ snapshots:
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
+
+  has-own-prop@2.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -16840,6 +16877,8 @@ snapshots:
       unified: 11.0.5
 
   remove-accents@0.5.0: {}
+
+  repeat-string@1.6.1: {}
 
   require-like@0.1.2: {}
 


### PR DESCRIPTION
# Description

Jsonc parsing was added to the linter [here](https://github.com/cloudflare/templates/pull/393), but when the linter is run with the "fix" option, comments are stripped from the jsonc files. This change preserves the comments by introducing a jsonc-specific writer with a comment-preserving library.

To replicate on staging or main, add a comment to a wrangler.jsonc file in one of the templates where dash is set to true in the package.json. Then, run `pnpm -w fix:ci`. The comment will no longer be in the wrangler.jsonc file, but there may be some whitespace changes due to the way the library parses the contents.

To test this change on this fix branch, do the same steps and the comment should remain.

