### PR TITLE
Remove --frozen-lockfile

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -24,5 +24,5 @@ runs:
         cache: "pnpm"
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile --child-concurrency=10
+      run: pnpm install --child-concurrency=10
       shell: bash


### PR DESCRIPTION
The pnpm `--frozen-lockfile` flag prevents installs whenever there are updates to subdirectory package.json deps without changing the top-level pnpm lock file, e.g. dependabot updates. Further, we should still get the benefits of `--frozen-lockfile` because pnpm states that it is the default in CI environments, so we should let pnpm decide.