### PR TITLE
Dont use frozen lockfile

### DIFF
--- a/.github/workflows/pull-request-deps.yaml
+++ b/.github/workflows/pull-request-deps.yaml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm -w fix:deps
 
       - name: Install updated packages
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile --child-concurrency=10
 
       - name: Re-run other fixes with updated packages
         run: pnpm -w fix


### PR DESCRIPTION
For dependabot updates, we dont want to use the lockfile since dependabot doesnt update that