### PR TITLE
Replace depenabot version updates with syncpack updates

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -2,7 +2,7 @@ name: "Update Dependencies"
 
 on:
   schedule:
-    - cron: '0 13 * * 1'
+    - cron: "0 13 * * 1"
 
 jobs:
   update-dependencies:

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -1,0 +1,15 @@
+name: "Update Dependencies"
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: ./.github/actions/setup
+
+      - name: "Process and update dependencies"
+        run: "pnpm -w update:deps"

--- a/cli/src/depsInfo.ts
+++ b/cli/src/depsInfo.ts
@@ -1,7 +1,8 @@
 import {
   commentOnPR,
-  convertToMarkdownTable, getLatestPackageVersion,
-  TEMPLATE_DIRECTORY_SUFFIX
+  convertToMarkdownTable,
+  getLatestPackageVersion,
+  TEMPLATE_DIRECTORY_SUFFIX,
 } from "./util";
 
 export type DepsInfoConfig = {

--- a/cli/src/depsInfo.ts
+++ b/cli/src/depsInfo.ts
@@ -1,7 +1,7 @@
 import {
   commentOnPR,
-  convertToMarkdownTable,
-  TEMPLATE_DIRECTORY_SUFFIX,
+  convertToMarkdownTable, getLatestPackageVersion,
+  TEMPLATE_DIRECTORY_SUFFIX
 } from "./util";
 
 export type DepsInfoConfig = {
@@ -98,19 +98,6 @@ async function getPackageJSON(url: string) {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   };
-}
-
-async function getLatestPackageVersion(packageName: string) {
-  const response = await fetch(
-    `https://registry.npmjs.org/${packageName}/latest`,
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Error response from ${response.url} (${response.status}): ${await response.text()}`,
-    );
-  }
-  const { version } = (await response.json()) as { version: string };
-  return version;
 }
 
 async function makeDepsInfo(

--- a/cli/src/depsInfo.ts
+++ b/cli/src/depsInfo.ts
@@ -60,8 +60,8 @@ export async function depsInfo({ prId, githubToken }: DepsInfoConfig) {
     }
   }
   deps.sort((a, b) => {
-    if (a.template < b.template) return 1;
-    if (a.template > b.template) return -1;
+    if (a.template < b.template) return -1;
+    if (a.template > b.template) return 1;
     return 0;
   });
   await commentOnPR({

--- a/cli/src/depsUpdate.ts
+++ b/cli/src/depsUpdate.ts
@@ -1,6 +1,10 @@
 import "zx/globals";
 import subprocess from "node:child_process";
-import { convertToMarkdownTable, createPR, getLatestPackageVersion } from "./util";
+import {
+  convertToMarkdownTable,
+  createPR,
+  getLatestPackageVersion,
+} from "./util";
 
 export type DepsUpdateConfig = {
   githubToken: string;

--- a/cli/src/depsUpdate.ts
+++ b/cli/src/depsUpdate.ts
@@ -1,0 +1,111 @@
+import "zx/globals";
+import subprocess from "node:child_process";
+import { convertToMarkdownTable, getLatestPackageVersion } from "./util";
+
+export type DepsUpdateConfig = {
+  githubToken: string;
+  githubActor: string;
+};
+
+export async function depsUpdate({
+  githubToken,
+  githubActor,
+}: DepsUpdateConfig) {
+  const packages = getPackages();
+  const toUpdate = new Map<string, { packages: string[]; version: string }>();
+  const alreadyLatest = new Set();
+  for (const pkg of packages) {
+    for (const dependencies of [
+      pkg.dependencies || {},
+      pkg.devDependencies || {},
+    ]) {
+      for (const [depName, info] of Object.entries(dependencies)) {
+        if (toUpdate.has(depName)) {
+          toUpdate.get(depName)?.packages.push(pkg.name);
+          continue;
+        }
+        if (alreadyLatest.has(depName)) {
+          continue;
+        }
+        const latestVersion = await getLatestPackageVersion(depName);
+        if (latestVersion === info.version) {
+          alreadyLatest.add(depName);
+        } else {
+          toUpdate.set(depName, {
+            packages: [pkg.name],
+            version: latestVersion,
+          });
+        }
+      }
+    }
+  }
+
+  // subprocess.execSync(`git config --global user.name "${githubActor}"`);
+  // subprocess.execSync(
+  //   `git config --global user.email "${githubActor}@users.noreply.github.com"`,
+  // );
+  const date = new Date().toISOString().slice(0, 10);
+  const depsToPRs = new Map();
+  for (const [depName, { packages, version }] of toUpdate) {
+    const head = `syncpack/${depName}-${date}`;
+    const base = "main";
+    const title = `syncpack update ${depName} to ${version}`;
+    echo(chalk.yellow(title));
+    const body = [
+      `Update ${depName} in the following packages:`,
+      ...packages.map((packageName) => `- ${packageName}`),
+    ].join("\n");
+    subprocess.execSync(`
+      git checkout -b ${head} ${base}
+      syncpack update --filter '${depName}'
+      if [[ -n "$(git diff --exit-code)" ]]; then
+        git add .
+        git commit -m '${title}'
+        # git push
+      fi
+      `);
+    // const { id, url } = await createPullRequest({
+    //   githubToken,
+    //   head,
+    //   base,
+    //   title,
+    //   body,
+    // });
+    // depsToPRs.set(depName, `[#${id}](${url})`);
+  }
+  const arr = Array.from(toUpdate).map(([depName, { packages, version }]) => ({
+    dependency: depName,
+    version,
+    affected: `<ul>${packages.map((item) => `<li>${item}</li>`).join("")}</ul>`,
+    PR: depsToPRs.get(depName),
+  }));
+  arr.sort((a, b) => {
+    if (a.dependency < b.dependency) return 1;
+    if (a.dependency > b.dependency) return -1;
+    return 0;
+  });
+  return convertToMarkdownTable(arr);
+}
+
+type PNPMPackageDependency = {
+  from: string;
+  version: string;
+  path: string;
+  resolved?: string;
+};
+
+type PNPMPackageInfo = {
+  name: string;
+  path: string;
+  private: boolean;
+  dependencies?: Record<string, PNPMPackageDependency>;
+  devDependencies?: Record<string, PNPMPackageDependency>;
+};
+
+function getPackages() {
+  const result = subprocess.execSync("pnpm list --recursive --json", {
+    encoding: "utf-8",
+  });
+  return JSON.parse(result) as PNPMPackageInfo[];
+}
+//# sourceMappingURL=depsUpdate.js.map

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { actionWithSummary } from "./util";
 import { validateD2CButtons } from "./validateD2CButtons";
 import { setupHooks } from "./setupHooks";
 import { depsInfo } from "./depsInfo";
+import { depsUpdate } from "./depsUpdate";
 
 const program = new Command();
 
@@ -179,6 +180,25 @@ program
       depsInfo({
         prId: options.pr,
         githubToken,
+      }),
+    );
+  });
+
+program
+  .command("deps-update")
+  .description(
+    "Creates pull requests for each dependency that requires updating",
+  )
+  .requiredOption("--actor <string>", "the actor of the GitHub action")
+  .action((options) => {
+    // const githubToken = process.env.GITHUB_TOKEN;
+    // if (!githubToken) {
+    //   throw new Error("Missing GITHUB_TOKEN");
+    // }
+    return actionWithSummary("Deps Update", () =>
+      depsUpdate({
+        githubToken: "",
+        githubActor: options.actor,
       }),
     );
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -191,13 +191,13 @@ program
   )
   .requiredOption("--actor <string>", "the actor of the GitHub action")
   .action((options) => {
-    // const githubToken = process.env.GITHUB_TOKEN;
-    // if (!githubToken) {
-    //   throw new Error("Missing GITHUB_TOKEN");
-    // }
+    const githubToken = process.env.GITHUB_TOKEN;
+    if (!githubToken) {
+      throw new Error("Missing GITHUB_TOKEN");
+    }
     return actionWithSummary("Deps Update", () =>
       depsUpdate({
-        githubToken: "",
+        githubToken,
         githubActor: options.actor,
       }),
     );

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -288,7 +288,7 @@ export async function createPR({ githubToken, ...params }: CreatePRConfig) {
       `Error response from GitHub (${response.status}): ${await response.text()}`,
     );
   }
-  return await response.json() as { url: string, id: number };
+  return (await response.json()) as { url: string; id: number };
 }
 
 export async function getLatestPackageVersion(packageName: string) {

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -263,6 +263,20 @@ export async function isDuplicateComment({
   return comments.find((comment) => comment.body === body);
 }
 
+
+export async function getLatestPackageVersion(packageName: string) {
+  const response = await fetch(
+      `https://registry.npmjs.org/${packageName}/latest`,
+  );
+  if (!response.ok) {
+    throw new Error(
+        `Error response from ${response.url} (${response.status}): ${await response.text()}`,
+    );
+  }
+  const { version } = (await response.json()) as { version: string };
+  return version;
+}
+
 export function convertToMarkdownTable(arr: Array<Record<string, unknown>>) {
   if (!arr || arr.length === 0) {
     return "";

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -263,14 +263,13 @@ export async function isDuplicateComment({
   return comments.find((comment) => comment.body === body);
 }
 
-
 export async function getLatestPackageVersion(packageName: string) {
   const response = await fetch(
-      `https://registry.npmjs.org/${packageName}/latest`,
+    `https://registry.npmjs.org/${packageName}/latest`,
   );
   if (!response.ok) {
     throw new Error(
-        `Error response from ${response.url} (${response.status}): ${await response.text()}`,
+      `Error response from ${response.url} (${response.status}): ${await response.text()}`,
     );
   }
   const { version } = (await response.json()) as { version: string };

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -263,6 +263,34 @@ export async function isDuplicateComment({
   return comments.find((comment) => comment.body === body);
 }
 
+export type CreatePRConfig = {
+  githubToken: string;
+  head: string;
+  base: string;
+  title: string;
+  body: string;
+};
+
+export async function createPR({ githubToken, ...params }: CreatePRConfig) {
+  const response = await fetch(
+    `https://api.github.com/repos/cloudflare/templates/pulls`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${githubToken}`,
+      },
+      body: JSON.stringify(params),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Error response from GitHub (${response.status}): ${await response.text()}`,
+    );
+  }
+  return await response.json() as { url: string, id: number };
+}
+
 export async function getLatestPackageVersion(packageName: string) {
   const response = await fetch(
     `https://registry.npmjs.org/${packageName}/latest`,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "preview": "templates preview",
     "test": "turbo run test -- --passWithNoTests",
     "test:cli": "vitest",
+    "update:deps": "templates deps-update",
     "upload": "templates upload",
     "validate-d2c-buttons": "templates validate-d2c-buttons",
     "validate-live-demo-links": "templates validate-live-demo-links"


### PR DESCRIPTION
We want to ignore updating specific dependencies in specific template subdirectories, but we dont want to make a dependabot config for each subdirectory. You _can_ ignore dependencies in a dependabot config, but it applies to all directories in the scope of a given config, and we have just one config for all directories.

Instead, we will opt to run `syncpack update` regularly, which would pull the latest versions whilst still adhering to our syncpack rules of which deps to never update.

We will automate this to run on a given schedule using github actions, and turn off dependabot for version updates (but keep it for security updates).