### PR TITLE
Fix missing directory property in vite-react-template assets configuration

### DIFF
--- a/vite-react-template/wrangler.json
+++ b/vite-react-template/wrangler.json
@@ -9,6 +9,7 @@
   },
   "upload_source_maps": true,
   "assets": {
+    "directory": "./dist/client",
     "not_found_handling": "single-page-application"
   }
 }


### PR DESCRIPTION
# Description

Fixes this error when running `npx wrangler deploy`:

```✘ [ERROR] The `assets` property in your configuration is missing the required `directory` property.```