### PR TITLE
Deploy live demos in isolation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm -w test
 
       - name: Deploy live demos
-        run: pnpm run deploy # pnpm deploy is a whole other thing apparently
+        run: pnpm -w deploy-live-demos
 
       - name: Validate live demo links
         run: pnpm -w validate-live-demo-links

--- a/cli/src/deployLiveDemos.ts
+++ b/cli/src/deployLiveDemos.ts
@@ -1,0 +1,26 @@
+import "zx/globals";
+import subprocess from "node:child_process";
+import { getTemplates } from "./util";
+
+export type DeployLiveDemosConfig = {
+  templateDirectory: string;
+};
+
+export default async function deployLiveDemos({
+  templateDirectory,
+}: DeployLiveDemosConfig) {
+  const templates = getTemplates(templateDirectory);
+  await Promise.all(
+    templates.map(({ path: templatePath }) => {
+      subprocess.execSync("npm install", {
+        cwd: templatePath,
+      });
+      subprocess.execSync("npm run build --if-present", {
+        cwd: templatePath,
+      });
+      subprocess.execSync("npm run deploy", {
+        cwd: templatePath,
+      });
+    }),
+  );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import { validateD2CButtons } from "./validateD2CButtons";
 import { setupHooks } from "./setupHooks";
 import { depsInfo } from "./depsInfo";
 import { depsUpdate } from "./depsUpdate";
+import deployLiveDemos from "./deployLiveDemos";
 
 const program = new Command();
 
@@ -97,6 +98,20 @@ program
   .action((templateDirectory) => {
     return actionWithSummary("Lint npm lockfiles", () =>
       lintNpmLockfiles({ templateDirectory }),
+    );
+  });
+
+program
+  .command("deploy-live-demos")
+  .description("Builds and deploys each template in isolataion")
+  .argument(
+    "[path-to-template(s)]",
+    "path to directory containing template(s)",
+    ".",
+  )
+  .action((templateDirectory) => {
+    return actionWithSummary("Deploy live demos", () =>
+      deployLiveDemos({ templateDirectory }),
     );
   });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:templates": "templates lint .",
     "check:turbo": "turbo run check cf-typegen --force",
     "deploy": "turbo run deploy",
+    "deploy-live-demos": "templates deploy-live-demos .",
     "fix": "pnpm run fix:templates && pnpm run fix:lockfiles && pnpm run fix:turbo && pnpm run fix:prettier",
     "fix:deps": "syncpack format && syncpack fix-mismatches",
     "fix:lockfiles": "templates generate-npm-lockfiles .",


### PR DESCRIPTION
Certain dependencies (like opennext) require the isolated dependency structure found when running `npm install` within the given template directory.