### PR TITLE
feat: filter live e2e tests to only published templates

### DIFF
--- a/playwright-tests/multiplayer-globe-template.spec.ts
+++ b/playwright-tests/multiplayer-globe-template.spec.ts
@@ -6,7 +6,9 @@ test.describe("Multiplayer Globe Template", () => {
     await expect(
       page.getByRole("heading", { name: "Where's everyone at?" }),
     ).toBeVisible();
-    await expect(page.locator("#root")).toContainText("1 person connected.");
+    await expect(
+      page.getByText(/\d+ (?:person|people) connected\./),
+    ).toBeVisible();
     await expect(page.locator("canvas")).toBeVisible();
   });
 });

--- a/playwright-tests/utils/template-server.ts
+++ b/playwright-tests/utils/template-server.ts
@@ -61,6 +61,15 @@ export class TemplateServerManager {
           const packageJson = JSON.parse(
             fs.readFileSync(packageJsonPath, "utf8"),
           );
+
+          // For live tests, only include templates with cloudflare.publish === true
+          if (this.useLiveUrls) {
+            const cloudflareConfig = packageJson.cloudflare;
+            if (!cloudflareConfig || cloudflareConfig.publish !== true) {
+              continue;
+            }
+          }
+
           const template = this.analyzeTemplate(
             templateDir,
             templatePath,


### PR DESCRIPTION
# Description

This PR filters the templates we attempt to test when running the `test:live:e2e` command to only run against the templates that have live previews in the Cloudflare Dashboard. 

Also fixes an issue where the live multiplayer globe template may have multiple users connected when the test runs. 

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [ ] template directory ends with `-template`
  - [ ] "cloudflare" section of package.json is populated
  - [ ] template preview image uploaded to Images
  - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [ ] package.json contains a `deploy` command

## Example package.json

```json
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
