### PR TITLE
fix: resolve TypeScript errors in react-router-hono-fullstack-template

### DIFF
--- a/react-router-hono-fullstack-template/app/routes/home.tsx
+++ b/react-router-hono-fullstack-template/app/routes/home.tsx
@@ -9,7 +9,9 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export function loader({ context }: Route.LoaderArgs) {
-  return { message: context.cloudflare.env.VALUE_FROM_CLOUDFLARE };
+  return {
+    message: (context.cloudflare as { env: Env }).env.VALUE_FROM_CLOUDFLARE,
+  };
 }
 
 export default function Home({ loaderData }: Route.ComponentProps) {

--- a/react-router-hono-fullstack-template/workers/app.ts
+++ b/react-router-hono-fullstack-template/workers/app.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { createRequestHandler } from "react-router";
 
-const app = new Hono();
+const app = new Hono<{ Bindings: Env }>();
 
 // Add more routes here
 


### PR DESCRIPTION
## Summary
- Fixes TypeScript compilation errors in the react-router-hono-fullstack-template
- Adds proper typing for the Hono app instance and context.cloudflare access

## Changes
1. **app/routes/home.tsx**: Added type assertion for `context.cloudflare` to properly access the `env` property
2. **workers/app.ts**: Added `{ Bindings: Env }` generic type to the Hono app instance

## Test plan
- [x] Run `npm install` in the template directory
- [x] Run `npm run typecheck` - should complete without errors
- [x] Run `npm run dev` - application should work as before
- [x] Verify the template still functions correctly with these type fixes

These minimal changes ensure TypeScript compilation works while maintaining full functionality.