### PR TITLE
chore(containers-template): Use the Env type from `wrangler types`

### DIFF
--- a/containers-template/src/index.ts
+++ b/containers-template/src/index.ts
@@ -1,7 +1,7 @@
 import { Container, loadBalance, getContainer } from "@cloudflare/containers";
 import { Hono } from "hono";
 
-export class MyContainer extends Container {
+export class MyContainer extends Container<Env> {
   // Port the container listens on (default: 8080)
   defaultPort = 8080;
   // Time before container sleeps due to inactivity (default: 30s)
@@ -27,7 +27,7 @@ export class MyContainer extends Container {
 
 // Create Hono app with proper typing for Cloudflare Workers
 const app = new Hono<{
-  Bindings: { MY_CONTAINER: DurableObjectNamespace<MyContainer> };
+  Bindings: Env;
 }>();
 
 // Home route with available endpoints


### PR DESCRIPTION
# Description

Uses the existing `Env` type from `wrangler types` when telling Hono what the `Bindings` are but also in the `Container` generic.