### PR TITLE
Add Observability call out as a feature in Worker templates

### DIFF
--- a/astro-blog-starter-template/README.md
+++ b/astro-blog-starter-template/README.md
@@ -16,6 +16,7 @@ Features:
 - ✅ Sitemap support
 - ✅ RSS Feed support
 - ✅ Markdown & MDX support
+- ✅ Built-in Observability logging
 
 <!-- dash-content-end -->
 
@@ -52,6 +53,7 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`               | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help`         | Get help using the Astro CLI                     |
 | `npm run build && npm run deploy` | Deploy your production site to Cloudflare        |
+| `npm wrangler tail`               | View real-time logs for all Workers              |
 
 ## 👀 Want to learn more?
 

--- a/llm-chat-app-template/README.md
+++ b/llm-chat-app-template/README.md
@@ -23,6 +23,7 @@ This template demonstrates how to build an AI-powered chat interface using Cloud
 - 🛠️ Built with TypeScript and Cloudflare Workers
 - 📱 Mobile-friendly design
 - 🔄 Maintains chat history on the client
+- 🔎 Built-in Observability logging
 <!-- dash-content-end -->
 
 ## Getting Started
@@ -71,6 +72,14 @@ Deploy to Cloudflare Workers:
 
 ```bash
 npm run deploy
+```
+
+### Monitor
+
+View real-time logs associated with any deployed Worker:
+
+```bash
+npm wrangler tail
 ```
 
 ## Project Structure

--- a/openauth-template/README.md
+++ b/openauth-template/README.md
@@ -6,7 +6,7 @@
 
 <!-- dash-content-start -->
 
-[OpenAuth](https://openauth.js.org/) is a universal provider for managing user authentication. By deploying OpenAuth on Cloudflare Workers, you can add scalable authentication to your application. This demo showcases login, user registration, and password reset, with storage and state powered by [D1](https://developers.cloudflare.com/d1/) and [KV](https://developers.cloudflare.com/kv/).
+[OpenAuth](https://openauth.js.org/) is a universal provider for managing user authentication. By deploying OpenAuth on Cloudflare Workers, you can add scalable authentication to your application. This demo showcases login, user registration, and password reset, with storage and state powered by [D1](https://developers.cloudflare.com/d1/) and [KV](https://developers.cloudflare.com/kv/). [Observability](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#enable-workers-logs) is on by default.
 
 > [!IMPORTANT]
 > When using C3 to create this project, select "no" when it asks if you want to deploy. You need to follow this project's [setup steps](https://github.com/cloudflare/templates/tree/main/openauth-template#setup-steps) before deploying.

--- a/r2-explorer-template/README.md
+++ b/r2-explorer-template/README.md
@@ -37,7 +37,9 @@ R2-Explorer brings a familiar Google Drive-like interface to your Cloudflare R2 
   - Receive and process emails via Cloudflare Email Routing
   - View email attachments directly in the interface
 
-<!-- dash-content-end -->
+- **🔎 Observability**
+  - View real-time logs associated with any deployed Worker using ```wrangler tail```
+  <!-- dash-content-end -->
 
 > [!IMPORTANT]
 > When using C3 to create this project, select "no" when it asks if you want to deploy. You need to follow this project's [setup steps](https://github.com/cloudflare/templates/tree/main/r2-explorer-template#setup-steps) before deploying.

--- a/react-router-hono-fullstack-template/README.md
+++ b/react-router-hono-fullstack-template/README.md
@@ -20,7 +20,7 @@ A perfect starting point for building interactive, styled, and edge-deployed SPA
 - 🧱 File-based route separation
 - 🚀 Zero-config Vite build for Workers
 - 🛠️ Automatically deploys with Wrangler
-
+- 🔎 Built-in Observability to monitor your Worker
 <!-- dash-content-end -->
 
 ## Tech Stack

--- a/react-router-starter-template/README.md
+++ b/react-router-starter-template/README.md
@@ -17,7 +17,7 @@ A modern, production-ready template for building full-stack React applications u
 - 🔒 TypeScript by default
 - 🎉 TailwindCSS for styling
 - 📖 [React Router docs](https://reactrouter.com/)
-
+- 🔎 Built-in Observability to monitor your Worker
 <!-- dash-content-end -->
 
 ## Getting Started

--- a/to-do-list-kv-template/README.md
+++ b/to-do-list-kv-template/README.md
@@ -10,7 +10,7 @@ Manage your to-do list with [Cloudflare Workers Assets](https://developers.cloud
 
 ## How It Works
 
-This is a simple to-do list app that allows you to add, remove, and mark tasks as complete. The project is a Cloudflare Workers Assets application built with Remix. It uses Cloudflare Workers KV to store the to do list items. The [Remix Vite Plugin](https://remix.run/docs/en/main/guides/vite#vite) has a Cloudflare Dev Proxy that enables you to use [Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/) provided by the Cloudflare Developer Platform.
+This is a simple to-do list app that allows you to add, remove, and mark tasks as complete. The project is a Cloudflare Workers Assets application built with Remix. It uses Cloudflare Workers KV to store the to do list items. The [Remix Vite Plugin](https://remix.run/docs/en/main/guides/vite#vite) has a Cloudflare Dev Proxy that enables you to use [Bindings](https://developers.cloudflare.com/workers/runtime-apis/bindings/) provided by the Cloudflare Developer Platform. [Observability](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#enable-workers-logs) is on by default.
 
 > [!IMPORTANT]
 > When using C3 to create this project, select "no" when it asks if you want to deploy. You need to follow this project's [setup steps](https://github.com/cloudflare/templates/tree/main/to-do-list-kv-template#setup-steps) before deploying.

--- a/vite-react-template/README.md
+++ b/vite-react-template/README.md
@@ -23,6 +23,7 @@ This template provides a minimal setup for building a React application with Typ
 - ⚡ Zero-config deployment to Cloudflare's global network
 - 🎯 API routes with Hono's elegant routing
 - 🔄 Full-stack development setup
+- 🔎 Built-in Observability to monitor your Worker
 
 Get started in minutes with local development or deploy directly via the Cloudflare dashboard. Perfect for building modern, performant web applications at the edge.
 


### PR DESCRIPTION
# Description

Addressing https://github.com/cloudflare/templates/pull/2 in this https://wiki.cfdata.org/display/WOBS/Improving+Discoverability+of+Workers+Observability 
# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [ ] template directory ends with `-template`
  - [ ] "cloudflare" section of package.json is populated
  - [ ] template preview image uploaded to Images
  - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [ ] package.json contains a `deploy` command

## Example package.json

```json
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
