### PR TITLE
chore(containers-template): Copy CA certificates to final scratch layer

### DIFF
--- a/containers-template/Dockerfile
+++ b/containers-template/Dockerfile
@@ -16,6 +16,7 @@ COPY container_src/*.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /server
 
 FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /server /server
 EXPOSE 8080
 


### PR DESCRIPTION
# Description

Without copying the CA certificates from another stage, the `scratch` layer has no CA store & therefore can't fetch HTTPS URLs.