### PR TITLE
Fix incorrect Record type in base.ts

### DIFF
--- a/chanfana-openapi-template/src/endpoints/tasks/base.ts
+++ b/chanfana-openapi-template/src/endpoints/tasks/base.ts
@@ -13,7 +13,7 @@ export const TaskModel = {
   tableName: "tasks",
   primaryKeys: ["id"],
   schema: task,
-  serializer: (obj: Record<string, string | number | boolean>) => {
+  serializer: (obj: Partial<Record<string, string | number | boolean>>) => {
     return {
       ...obj,
       completed: Boolean(obj.completed),


### PR DESCRIPTION
Fixes the following typescript error in all routes, since an empty object is not the same as `Record<string, string | number | boolean>`.


```text
Property '_meta' in type 'TaskCreate' is not assignable to the same property in base type 'D1CreateEndpoint<HandleArgs>'.
  Type '{ model: { tableName: string; primaryKeys: string[]; schema: ZodObject<{ id: ZodNumber; name: ZodString; slug: ZodString; description: ZodString; completed: ZodBoolean; due_date: ZodString; }, "strip", ZodTypeAny, { ...; }, { ...; }>; serializer: (obj: Record<string, string | number | boolean>) => { ...; }; serializ...' is not assignable to type 'MetaInput'.
    The types of 'model.serializer' are incompatible between these types.
      Type '(obj: Record<string, string | number | boolean>) => { completed: boolean; }' is not assignable to type '(obj: object) => object'.
        Types of parameters 'obj' and 'obj' are incompatible.
          Type 'object' is not assignable to type 'Record<string, string | number | boolean>'.
            Index signature for type 'string' is missing in type '{}'. [2416]
```

The key to this error is in the last line: `Index signature for type 'string' is missing in type '{}'.`, since there are no keys in an empty object.

# Description

Fixes #[insert GH or internal issue link(s)].

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [x] template directory ends with `-template`
  - [x] "cloudflare" section of `package.json` is populated
  - [x] template preview image uploaded to Images
  - [x] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [x] `.gitignore` file exists
  - [x] `package.json` contains a `deploy` command
  - [x] `package.json` contains `private: true` and no `version` field

## Example `package.json`

```json
"private": true,
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
