### PR TITLE
chanfana-openapi-template: Fix npm create invocation in README.md

### DIFF
--- a/chanfana-openapi-template/README.md
+++ b/chanfana-openapi-template/README.md
@@ -25,7 +25,7 @@ Besides being able to see the OpenAPI schema (openapi.json) in the browser, you 
 Outside of this repo, you can start a new project with this template using [C3](https://developers.cloudflare.com/pages/get-started/c3/) (the `create-cloudflare` CLI):
 
 ```bash
-npm create cloudflare@latest -- --template=cloudflare/templates/openapi-template
+npm create cloudflare@latest -- --template=cloudflare/templates/chanfana-openapi-template
 ```
 
 A live public deployment of this template is available at [https://openapi-template.templates.workers.dev](https://openapi-template.templates.workers.dev)


### PR DESCRIPTION
# Description

Fixes npm create invocation in chanfana-openapi-template.

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [ ] template directory ends with `-template`
  - [ ] "cloudflare" section of `package.json` is populated
  - [ ] template preview image uploaded to Images
  - [ ] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [ ] `.gitignore` file exists
  - [ ] `package.json` contains a `deploy` command
  - [ ] `package.json` contains `private: true` and no `version` field

## Example `package.json`

```json
"private": true,
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
