### PR TITLE
fix: workers for platforms upload

### DIFF
--- a/worker-publisher-template/scripts/deploy-wfp.ts
+++ b/worker-publisher-template/scripts/deploy-wfp.ts
@@ -48,11 +48,11 @@ export async function deploySnippetToNamespace(opts: {
 				main_module: moduleFileName,
 				bindings,
 			},
-			files: {
-				[moduleFileName]: await toFile(Buffer.from(code), moduleFileName, {
+			files: [
+				await toFile(Buffer.from(code), moduleFileName, {
 					type: "application/javascript+module",
 				}),
-			},
+			],
 		},
 	);
 

--- a/worker-publisher-template/src/index.ts
+++ b/worker-publisher-template/src/index.ts
@@ -47,11 +47,11 @@ async function deploySnippetToNamespace(
 				main_module: moduleFileName,
 				bindings,
 			},
-			files: {
-				[moduleFileName]: new File([code], moduleFileName, {
+			files: [
+				new File([code], moduleFileName, {
 					type: "application/javascript+module",
 				}),
-			},
+			],
 		},
 	);
 

--- a/worker-publisher-template/wrangler.jsonc
+++ b/worker-publisher-template/wrangler.jsonc
@@ -8,7 +8,7 @@
 		{
 			"binding": "DISPATCHER",
 			"namespace": "my-dispatch-namespace",
-			"experimental_remote": true
+			"remote": true
 		}
 	],
 	"observability": {


### PR DESCRIPTION
# Description

Fix Workers for Platforms script upload by passing files as an array instead of an object, matching the Cloudflare SDK's expected Array<Uploadable> type

The scripts.update method for Workers for Platforms expects files to be an Array<Uploadable>, but we were passing an object with filename keys:
// Before (incorrect)
files: {
  [moduleFileName]: new File([code], moduleFileName, {...}),
}
// After (correct)
files: [
  new File([code], moduleFileName, {...}),
]
This caused the SDK to serialize the files as JSON rather than multipart form data, resulting in the error:
module files has unsupported Content-Type application

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [x] template directory ends with `-template`
  - [x] "cloudflare" section of `package.json` is populated
  - [x] template preview image uploaded to Images
  - [x] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [x] `.gitignore` file exists
  - [x] `package.json` contains a `deploy` command
  - [x] `package.json` contains `private: true` and no `version` field

## Example `package.json`

```json
"private": true,
"cloudflare": {
  "label": "Worker + D1 Database",
  "products": [
    "Workers",
    "D1"
  ],
  "categories": [
    "storage"
  ],
  "docs_url": "https://developers.cloudflare.com/d1/",
  "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/cb7cb0a9-6102-4822-633c-b76b7bb25900/public"
}
```

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
