### PR TITLE
fix: prevent sql injection in durable-chat-template

### DIFF
--- a/durable-chat-template/src/server/index.ts
+++ b/durable-chat-template/src/server/index.ts
@@ -55,13 +55,12 @@ export class Chat extends Server<Env> {
 		}
 
 		this.ctx.storage.sql.exec(
-			`INSERT INTO messages (id, user, role, content) VALUES ('${
-				message.id
-			}', '${message.user}', '${message.role}', ${JSON.stringify(
-				message.content,
-			)}) ON CONFLICT (id) DO UPDATE SET content = ${JSON.stringify(
-				message.content,
-			)}`,
+			`INSERT INTO messages (id, user, role, content) VALUES (?, ?, ?, ?) ON CONFLICT (id) DO UPDATE SET content = ?`,
+			message.id,
+			message.user,
+			message.role,
+			message.content,
+			message.content,
 		);
 	}
 


### PR DESCRIPTION
# Description

Fixes SQL injection in `durable-chat-template`.

# Checklist

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Template Metadata
  - [x] template directory ends with `-template`
  - [x] "cloudflare" section of `package.json` is populated
  - [x] template preview image uploaded to Images
  - [x] README is populated and uses `<!-- dash-content-start -->` and `<!-- dash-content-end -->` to designate the Dash readme preview
  - [x] `.gitignore` file exists
  - [x] `package.json` contains a `deploy` command
  - [x] `package.json` contains `private: true` and no `version` field


<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
