### PR TITLE
Fix saas-admin-template e2e test timeout in live mode

### DIFF
--- a/playwright-tests/saas-admin-template.spec.ts
+++ b/playwright-tests/saas-admin-template.spec.ts
@@ -6,12 +6,23 @@ test.describe("SaaS Admin Template", () => {
 		await expect(
 			page.getByRole("heading", { name: "SaaS Admin Template" }),
 		).toBeVisible();
-		await page.getByRole("link", { name: "Go to admin" }).click();
-		await page.getByRole("link", { name: "Customers", exact: true }).click();
+		// Use Promise.all to click and wait for navigation simultaneously
+		// This avoids actionTimeout being used for navigation wait
+		await Promise.all([
+			page.waitForURL(/\/admin$/),
+			page.getByRole("link", { name: "Go to admin" }).click(),
+		]);
+		await Promise.all([
+			page.waitForURL(/\/admin\/customers$/),
+			page.getByRole("link", { name: "Customers", exact: true }).click(),
+		]);
 		await expect(
 			page.getByRole("heading", { name: "Customers" }),
 		).toBeVisible();
-		await page.getByRole("link", { name: "Subscriptions" }).click();
+		await Promise.all([
+			page.waitForURL(/\/admin\/subscriptions$/),
+			page.getByRole("link", { name: "Subscriptions" }).click(),
+		]);
 		await expect(page.getByText("Subscriptions").nth(2)).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the failing live e2e test for `saas-admin-template` that was causing CI failures on main.

**Root Cause:** The test was using `click()` on navigation links, which waits for navigation to complete using `actionTimeout` (5 seconds in live mode). The `/admin` page SSR can take longer than 5 seconds in the CI environment, causing timeouts.

**Fix:** Wrapped navigation clicks with `Promise.all([page.waitForURL(...), click()])` pattern. This separates the click action from the navigation wait, allowing navigation to use the longer `navigationTimeout` (15 seconds) instead of `actionTimeout` (5 seconds).

## Test

Verified locally against live URL:
```
PLAYWRIGHT_USE_LIVE=true pnpm exec playwright test playwright-tests/saas-admin-template.spec.ts
```

Related CI failure: https://github.com/cloudflare/templates/actions/runs/20783982439/job/59688307379