### PR TITLE
Set live D1 database ID for workers-for-platforms-template CI deployment

### DIFF
--- a/workers-for-platforms-template/wrangler.jsonc
+++ b/workers-for-platforms-template/wrangler.jsonc
@@ -30,7 +30,7 @@
 		{
 			"binding": "DB",
 			"database_name": "workers-for-platforms-template",
-			"database_id": "placeholder-will-be-auto-provisioned"
+			"database_id": "39f0ae3f-5dbc-4357-aa4d-bc52ce832621"
 		}
 	],
 	// Environment variables


### PR DESCRIPTION
## Summary
- Updates `workers-for-platforms-template/wrangler.jsonc` with the live D1 database ID for CI deployment

### Live Resources
- **D1 Database**: `workers-for-platforms-template` (ID: `39f0ae3f-5dbc-4357-aa4d-bc52ce832621`)
- **Dispatch Namespace**: `workers-for-platforms-template`
- **Live Preview**: https://workers-for-platforms-template.templates.workers.dev