### PR TITLE
fix(openauth-template): cast KVNamespace to fix type mismatch

### DIFF
--- a/openauth-template/src/index.ts
+++ b/openauth-template/src/index.ts
@@ -39,7 +39,8 @@ export default {
 		// The real OpenAuth server code starts here:
 		return issuer({
 			storage: CloudflareStorage({
-				namespace: env.AUTH_STORAGE,
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				namespace: env.AUTH_STORAGE as any,
 			}),
 			subjects,
 			providers: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
         specifier: 1.2.0
         version: 1.2.0(typescript@5.9.3)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260107.1
+        version: 4.20260107.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Fixes CI type check failure in openauth-template
- The `@openauthjs/openauth` library imports `KVNamespace` from `@cloudflare/workers-types`, but we use wrangler's generated runtime types which define their own `KVNamespace`
- These types are structurally compatible at runtime but TypeScript sees them as incompatible
- Using `as any` cast resolves the type mismatch

This was blocking other PRs like #906 from passing CI.