### PR TITLE
refactor(next-starter-template): consolidate build into opennextjs-cloudflare

### DIFF
--- a/next-starter-template/package.json
+++ b/next-starter-template/package.json
@@ -31,13 +31,14 @@
 	},
 	"private": true,
 	"scripts": {
-		"build": "next build",
+		"build": "opennextjs-cloudflare build",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts",
 		"check": "npm run build && tsc",
-		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"deploy": "opennextjs-cloudflare deploy",
 		"dev": "next dev",
 		"lint": "next lint",
-		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-		"start": "next start"
+		"preview": "opennextjs-cloudflare preview",
+		"start": "next start",
+		"upload": "opennextjs-cloudflare upload"
 	}
 }


### PR DESCRIPTION
## Summary
- Change `build` script to use `opennextjs-cloudflare build` instead of `next build`
- Remove redundant build step from `deploy` and `preview` scripts
- Add `upload` script for `opennextjs-cloudflare upload`

This consolidates the build step so that `deploy` and `preview` no longer need to run the build themselves - users can run `npm run build` first, then run deploy/preview/upload as needed.