### PR TITLE
[opencode] VULN-117372 Fix SQL injection vulnerability in durable-chat-template

### DIFF
--- a/durable-chat-template/src/server/index.ts
+++ b/durable-chat-template/src/server/index.ts
@@ -54,14 +54,15 @@ export class Chat extends Server<Env> {
 			this.messages.push(message);
 		}
 
+		// Use parameterized queries to prevent SQL injection
 		this.ctx.storage.sql.exec(
-			`INSERT INTO messages (id, user, role, content) VALUES ('${
-				message.id
-			}', '${message.user}', '${message.role}', ${JSON.stringify(
-				message.content,
-			)}) ON CONFLICT (id) DO UPDATE SET content = ${JSON.stringify(
-				message.content,
-			)}`,
+			`INSERT INTO messages (id, user, role, content) VALUES (?, ?, ?, ?)
+			 ON CONFLICT (id) DO UPDATE SET content = ?`,
+			message.id,
+			message.user,
+			message.role,
+			message.content,
+			message.content,
 		);
 	}
 


### PR DESCRIPTION
# Description

Fixes #VULN-117372

Have tested changes with a deployed version of the DO template: https://durable-chat-template.kylieski.workers.dev

_Description from OpenCode:_

This change fixes a SQL injection vulnerability in the durable-chat-template. The `saveMessage` method was building SQL queries using string interpolation, which is dangerous because user-provided values (like message.user or message.content) were being inserted directly into the query string.

**Before:**
```jsx
this.ctx.storage.sql.exec(
  `INSERT INTO messages (id, user, role, content) VALUES ('${message.id}', '${message.user}', ...)`
);
```

**After:**
```jsx
this.ctx.storage.sql.exec(
  `INSERT INTO messages (id, user, role, content) VALUES (?, ?, ?, ?) ...`,
  message.id,
  message.user,
  message.role,
  message.content,
);
```

Using parameterized queries (? placeholders) ensures user input is properly escaped and can never be interpreted as SQL commands.