### PR TITLE
fix(microfrontend-template): pass through WebSocket upgrade responses as-is

### DIFF
--- a/microfrontend-template/index.ts
+++ b/microfrontend-template/index.ts
@@ -869,6 +869,14 @@ async function handleMountedApp(
 	const upstreamResp = await upstream.fetch(
 		new Request(forwardUrl.toString(), request),
 	);
+
+	// WebSocket upgrades must be returned as-is — do not wrap in a new Response,
+	// as that would strip the WebSocket pair from the response and break the connection.
+	// This applies to Durable Objects, Agents SDK, PartyKit, and any other WebSocket upgrade.
+	if (upstreamResp.status === 101) {
+		return upstreamResp;
+	}
+
 	const headers = new Headers(upstreamResp.headers);
 	const contentType = headers.get("content-type") || "";
 


### PR DESCRIPTION
## Title:
fix(microfrontend-template): pass through WebSocket upgrade responses as-is

## Description
Fixes a bug where WebSocket connections through the microfrontend router would silently fail.

When an upstream service (Durable Objects, Agents SDK, PartyKit, etc.) responds with HTTP 101 (WebSocket upgrade), the response must be returned directly. The existing passthrough path wrapped the response in `new Response(upstreamResp.body, ...)`, which drops the `webSocket` property that carries the client-side WebSocket object. The connection appears to establish but immediately closes.

The fix adds an early return for `status === 101` responses immediately after `upstream.fetch()`, before any header or body processing.

## Checklist
This PR modifies an existing template file only — no new template is being introduced, so the new-template checklist does not apply.

- [x] Existing template (`microfrontend-template`) is unaffected for all non-WebSocket traffic
- [x] Fix is non-breaking: the early return only triggers on HTTP 101 responses