### PR TITLE
Add run_worker_first to fix api route in vite-react example

### DIFF
--- a/vite-react-template/wrangler.json
+++ b/vite-react-template/wrangler.json
@@ -10,6 +10,7 @@
 	"upload_source_maps": true,
 	"assets": {
 		"directory": "./dist/client",
+		"run_worker_first": ["/api/*"],
 		"not_found_handling": "single-page-application"
 	}
 }


### PR DESCRIPTION
The included worker is not called even though included which would be unexpected for new users.

Fixes #524 and #409
