### PR TITLE
docs: fix chanfana template path

### DIFF
--- a/chanfana-openapi-template/README.md
+++ b/chanfana-openapi-template/README.md
@@ -25,7 +25,7 @@ Besides being able to see the OpenAPI schema (openapi.json) in the browser, you 
 Outside of this repo, you can start a new project with this template using [C3](https://developers.cloudflare.com/pages/get-started/c3/) (the `create-cloudflare` CLI):
 
 ```bash
-npm create cloudflare@latest -- --template=cloudflare/templates/openapi-template
+npm create cloudflare@latest -- --template=cloudflare/templates/chanfana-openapi-template
 ```
 
 A live public deployment of this template is available at [https://openapi-template.templates.workers.dev](https://openapi-template.templates.workers.dev)


### PR DESCRIPTION
## Summary
- fix the C3 command in `chanfana-openapi-template/README.md` so it points to the correct template path
- keep the README scaffolding example aligned with the actual template directory

## Test plan
- verified the broken path reported in the issue
- updated the command to `cloudflare/templates/chanfana-openapi-template`
- checked the resulting one-line git diff

Fixes #955