### PR TITLE
Harden x402 proxy route matching

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -82,7 +82,7 @@
       "package_json_hash": "8115cbe5e208ddc41eabdab0589922dfafdfbccc"
     },
     "x402-proxy-template": {
-      "package_json_hash": "85cf0e355a64d995bf663b8831ee9b9562f41c16"
+      "package_json_hash": "45c51e72eea511d77299365594d0f1507f87abbc"
     },
     "workflows-starter-template": {
       "package_json_hash": "61516050b40ccfaab285efad5c50719c3aff4f2c"

--- a/x402-proxy-template/package-lock.json
+++ b/x402-proxy-template/package-lock.json
@@ -29,9 +29,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -219,16 +219,16 @@
 			}
 		},
 		"node_modules/@coinbase/cdp-sdk": {
-			"version": "1.48.3",
-			"resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.48.3.tgz",
-			"integrity": "sha512-1fldOyJw/vjk42GsOCQ2pys/3r3LXHq8wZyhnt6OXkFfKirCjZiw966PT0vFcI/IzIQnhDgSeG7Tlt7kul3osg==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.55.0.tgz",
+			"integrity": "sha512-5PbUg3n3Jk9nm8nEStskRv6jTrVZKkgwxMFjW+i/xUDDzK1fXksKwXdjgUiHB1hf0FZx1LiYBosrh4IULxFyPA==",
 			"license": "MIT",
 			"dependencies": {
 				"@solana-program/system": "^0.10.0",
 				"@solana-program/token": "^0.9.0",
 				"@solana/kit": "^5.5.1",
 				"abitype": "1.0.6",
-				"axios": "1.13.6",
+				"axios": "1.16.0",
 				"axios-retry": "^4.5.0",
 				"bs58": "^6.0.0",
 				"jose": "^6.2.0",
@@ -236,12 +236,32 @@
 				"uncrypto": "^0.1.3",
 				"viem": "^2.47.0",
 				"zod": "^3.25.76"
+			},
+			"peerDependencies": {
+				"@x402/core": "^2.21.0",
+				"@x402/evm": "^2.21.0",
+				"@x402/extensions": "^2.21.0",
+				"@x402/svm": "^2.21.0"
+			},
+			"peerDependenciesMeta": {
+				"@x402/core": {
+					"optional": true
+				},
+				"@x402/evm": {
+					"optional": true
+				},
+				"@x402/extensions": {
+					"optional": true
+				},
+				"@x402/svm": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@coinbase/cdp-sdk/node_modules/ox": {
-			"version": "0.14.20",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
-			"integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+			"version": "0.14.33",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+			"integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -269,9 +289,9 @@
 			}
 		},
 		"node_modules/@coinbase/cdp-sdk/node_modules/ox/node_modules/abitype": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
-			"integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+			"integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/wevm"
@@ -290,9 +310,9 @@
 			}
 		},
 		"node_modules/@coinbase/cdp-sdk/node_modules/viem": {
-			"version": "2.48.11",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.48.11.tgz",
-			"integrity": "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==",
+			"version": "2.55.13",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.55.13.tgz",
+			"integrity": "sha512-Rt1NAsdtTdvJgqaCxsv2TuO55xv2d2dKEuRuzrg34xMGxvTSFOX0iIFvEfymPvh+fwN2tbgEU2JwN0YHOVM+Bg==",
 			"funding": [
 				{
 					"type": "github",
@@ -307,8 +327,8 @@
 				"@scure/bip39": "1.6.0",
 				"abitype": "1.2.3",
 				"isows": "1.0.7",
-				"ox": "0.14.20",
-				"ws": "8.18.3"
+				"ox": "0.14.33",
+				"ws": "8.21.0"
 			},
 			"peerDependencies": {
 				"typescript": ">=5.0.4"
@@ -341,9 +361,9 @@
 			}
 		},
 		"node_modules/@coinbase/cdp-sdk/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -471,9 +491,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -924,9 +944,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -968,9 +988,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1018,9 +1038,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+			"integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1030,7 +1050,7 @@
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.1",
+				"js-yaml": "^4.3.0",
 				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
@@ -1042,9 +1062,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1340,6 +1360,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1357,6 +1380,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1374,6 +1400,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1391,6 +1420,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1408,6 +1440,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1425,6 +1460,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1442,6 +1480,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1459,6 +1500,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1476,6 +1520,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1499,6 +1546,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1522,6 +1572,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1545,6 +1598,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1568,6 +1624,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1591,6 +1650,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1614,6 +1676,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1637,6 +1702,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1761,9 +1829,9 @@
 			}
 		},
 		"node_modules/@lit-labs/ssr-dom-shim": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-			"integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+			"integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@lit/reactive-element": {
@@ -2264,9 +2332,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@metamask/superstruct": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@metamask/superstruct/-/superstruct-3.2.1.tgz",
-			"integrity": "sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@metamask/superstruct/-/superstruct-3.4.1.tgz",
+			"integrity": "sha512-caTaaBUcwBGbUNf3r0uT48upX4nECRbKhQ9pPOfW4sIkfcIUUDV4S9DZxq/5fuNPVt5KWpyd5xIIz0sP+iWLlg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.0.0"
@@ -2351,7 +2419,7 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@paulmillr/qr/-/qr-0.2.1.tgz",
 			"integrity": "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==",
-			"deprecated": "The package is now available as \"qr\": npm install qr",
+			"deprecated": "Switch to \"qr\" (new package name) for security updates: npm install qr",
 			"license": "(MIT OR Apache-2.0)",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
@@ -4429,29 +4497,29 @@
 			}
 		},
 		"node_modules/@solana/wallet-standard-features": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
-			"integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.4.0.tgz",
+			"integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@wallet-standard/base": "^1.1.0",
 				"@wallet-standard/features": "^1.1.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@speed-highlight/core": {
-			"version": "1.2.15",
-			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-			"integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+			"version": "1.2.24",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+			"integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/@tanstack/query-core": {
-			"version": "5.100.9",
-			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
-			"integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+			"version": "5.101.4",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+			"integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
 			"license": "MIT",
 			"peer": true,
 			"funding": {
@@ -4460,13 +4528,13 @@
 			}
 		},
 		"node_modules/@tanstack/react-query": {
-			"version": "5.100.9",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
-			"integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+			"version": "5.101.4",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+			"integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@tanstack/query-core": "5.100.9"
+				"@tanstack/query-core": "5.101.4"
 			},
 			"funding": {
 				"type": "github",
@@ -4500,9 +4568,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/lodash": {
-			"version": "4.17.24",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-			"integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+			"version": "4.17.25",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+			"integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
 			"license": "MIT"
 		},
 		"node_modules/@types/ms": {
@@ -4837,36 +4905,36 @@
 			}
 		},
 		"node_modules/@wallet-standard/app": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
-			"integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.1.tgz",
+			"integrity": "sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wallet-standard/base": "^1.1.0"
+				"@wallet-standard/base": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@wallet-standard/base": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-			"integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+			"integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
 			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@wallet-standard/features": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-			"integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+			"integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@wallet-standard/base": "^1.1.0"
+				"@wallet-standard/base": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@walletconnect/core": {
@@ -5031,9 +5099,9 @@
 			}
 		},
 		"node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.3.0"
@@ -5451,9 +5519,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/@x402/core": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@x402/core/-/core-2.11.0.tgz",
-			"integrity": "sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw==",
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/@x402/core/-/core-2.22.0.tgz",
+			"integrity": "sha512-hYySs/PvukqRipC2mKqrsn/jx2U/p5EGnN3clQ2CIcApwtoFuG77CqpC3Wy7Fdp/juW8t8quiPVnqGuIkfix1Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"zod": "^3.24.2"
@@ -5481,9 +5549,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5616,14 +5684,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.6",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+			"integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
+				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/axios-retry": {
@@ -5692,9 +5760,9 @@
 			"license": "MIT"
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+			"integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
 			"license": "MIT"
 		},
 		"node_modules/bowser": {
@@ -5704,9 +5772,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6238,37 +6306,16 @@
 			}
 		},
 		"node_modules/engine.io-client": {
-			"version": "6.6.4",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-			"integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+			"version": "6.6.6",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+			"integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.4.1",
 				"engine.io-parser": "~5.2.1",
-				"ws": "~8.18.3",
+				"ws": "~8.21.0",
 				"xmlhttprequest-ssl": "~2.1.1"
-			}
-		},
-		"node_modules/engine.io-client/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/engine.io-parser": {
@@ -6309,9 +6356,9 @@
 			}
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -6507,9 +6554,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6952,9 +6999,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6994,16 +7041,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -7089,9 +7136,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+			"integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7206,9 +7253,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -7253,9 +7300,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+			"integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7475,9 +7522,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+			"integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -7491,10 +7538,20 @@
 			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -7627,9 +7684,9 @@
 			}
 		},
 		"node_modules/lit-html": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-			"integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+			"integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@types/trusted-types": "^2.0.2"
@@ -7678,9 +7735,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
@@ -7875,9 +7932,9 @@
 			}
 		},
 		"node_modules/node-mock-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
-			"integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+			"integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
 			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
@@ -8026,9 +8083,9 @@
 			}
 		},
 		"node_modules/ox/node_modules/abitype": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
-			"integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+			"integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/wevm"
@@ -8134,9 +8191,9 @@
 			"license": "MIT"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8267,9 +8324,9 @@
 			}
 		},
 		"node_modules/porto/node_modules/abitype": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
-			"integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+			"integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/wevm"
@@ -8390,10 +8447,13 @@
 			"license": "MIT"
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.4",
@@ -8491,9 +8551,9 @@
 			}
 		},
 		"node_modules/readdirp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+			"integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20.19.0"
@@ -8594,9 +8654,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8732,9 +8792,9 @@
 			}
 		},
 		"node_modules/socket.io-parser": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-			"integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+			"version": "4.2.7",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+			"integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
 			"license": "MIT",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
@@ -8866,9 +8926,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9015,9 +9075,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
-			"integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+			"integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
 			"license": "MIT"
 		},
 		"node_modules/unenv": {
@@ -9364,13 +9424,13 @@
 			"license": "ISC"
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.20",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
+				"call-bind": "^1.0.9",
 				"call-bound": "^1.0.4",
 				"for-each": "^0.3.5",
 				"get-proto": "^1.0.1",
@@ -9955,9 +10015,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/x402-proxy-template/package.json
+++ b/x402-proxy-template/package.json
@@ -44,6 +44,7 @@
 		"format:check": "prettier --check .",
 		"lint": "npm run typecheck && npm run format:check && eslint .",
 		"lint:fix": "prettier --write . && eslint . --fix",
+		"test": "tsx --test test/index.test.ts",
 		"test:client": "tsx test-client.ts",
 		"typecheck": "tsc --noEmit"
 	},

--- a/x402-proxy-template/src/index.ts
+++ b/x402-proxy-template/src/index.ts
@@ -26,6 +26,31 @@ const BUILTIN_PROTECTED_PATHS: ProtectedRouteConfig[] = [
 const BUILT_IN_PUBLIC_PATHS = ["/__x402/health", "/__x402/config"];
 
 /**
+ * Get the request path without parsing the URL so normalization changes can be
+ * detected before making an authorization decision.
+ */
+function getRawPath(url: string): string {
+	const authorityStart = url.indexOf("://");
+	const pathStart = url.indexOf("/", authorityStart + 3);
+	if (pathStart === -1) {
+		return "/";
+	}
+
+	const queryStart = url.indexOf("?", pathStart);
+	return url.slice(pathStart, queryStart === -1 ? undefined : queryStart);
+}
+
+/**
+ * Reject paths whose resource identity changes when parsed as a URL. Forwarding
+ * such a path could make the authorization check and origin resolve it
+ * differently.
+ */
+function hasNonCanonicalPath(url: string): boolean {
+	const rawPath = getRawPath(url);
+	return rawPath !== new URL(url).pathname || rawPath.includes("//");
+}
+
+/**
  * Proxy a request to the origin server.
  *
  * Three modes:
@@ -102,7 +127,8 @@ async function proxyToOrigin(request: Request, env: Env): Promise<Response> {
  */
 function pathMatchesPattern(path: string, pattern: string): boolean {
 	if (pattern.endsWith("/*")) {
-		return path.startsWith(pattern.slice(0, -2));
+		const prefix = pattern.slice(0, -2);
+		return path === prefix || path.startsWith(`${prefix}/`);
 	}
 	return path === pattern;
 }
@@ -128,6 +154,10 @@ function findProtectedRouteConfig(
  * take precedence by being registered after this middleware
  */
 app.use("*", async (c, next) => {
+	if (hasNonCanonicalPath(c.req.url)) {
+		return c.json({ error: "Non-canonical request path" }, 400);
+	}
+
 	const path = c.req.path;
 	const protectedPatterns = c.env.PROTECTED_PATTERNS || [];
 

--- a/x402-proxy-template/test/index.test.ts
+++ b/x402-proxy-template/test/index.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import app from "../src";
+import type { Env } from "../src/env";
+
+function requestWithRawUrl(url: string): Request {
+	const request = new Request("https://example.com/");
+	Object.defineProperty(request, "url", { value: url });
+	return request;
+}
+
+function createEnv() {
+	let originFetchCalls = 0;
+	const env = {
+		ORIGIN_SERVICE: {
+			fetch: async () => {
+				originFetchCalls++;
+				return new Response("origin content");
+			},
+		},
+		PROTECTED_PATTERNS: [
+			{
+				pattern: "/premium/*",
+				price: "$0.01",
+				description: "Premium content",
+			},
+		],
+	} as unknown as Env;
+
+	return { env, getOriginFetchCalls: () => originFetchCalls };
+}
+
+describe("x402 protected route matching", () => {
+	it("rejects a leading dot segment instead of proxying protected content", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/./premium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 400);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("rejects parent segments instead of proxying protected content", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/free/../premium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 400);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("rejects percent-encoded dot segments", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/%2e/premium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 400);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("rejects repeated slashes instead of relying on origin normalization", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com//premium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 400);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("continues to protect canonical wildcard paths", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/premium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 500);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("protects the wildcard prefix itself", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/premium"),
+			env
+		);
+
+		assert.equal(response.status, 500);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("matches percent-encoded ordinary characters using Hono semantics", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/%70remium/secret"),
+			env
+		);
+
+		assert.equal(response.status, 500);
+		assert.equal(getOriginFetchCalls(), 0);
+	});
+
+	it("does not protect paths that merely share a wildcard prefix", async () => {
+		const { env, getOriginFetchCalls } = createEnv();
+
+		const response = await app.fetch(
+			requestWithRawUrl("https://example.com/premiumXYZ"),
+			env
+		);
+
+		assert.equal(response.status, 200);
+		assert.equal(await response.text(), "origin content");
+		assert.equal(getOriginFetchCalls(), 1);
+	});
+});


### PR DESCRIPTION
## Summary

- reject non-canonical request paths before route authorization or origin proxying
- require wildcard route matches to end at a path-segment boundary
- add regression coverage for dot segments, encoded dot segments, repeated slashes, canonical protected paths, and wildcard boundaries

Internal tracking: VULN-151271

## Validation

- `cd x402-proxy-template && npm test`
- `cd x402-proxy-template && npm run lint`
- `pnpm test`
- `pnpm run check`
