### PR TITLE
Clarify internal sites Access audience configuration

### DIFF
--- a/internal-sites-template/README.md
+++ b/internal-sites-template/README.md
@@ -78,19 +78,37 @@ Protect your Worker with Cloudflare Access so only company employees can access 
 
 Every request now requires company login. The Access application authenticates users at the edge, and the platform Worker verifies the signed Access JWT again before handling platform routes or dispatching deployed sites.
 
-**Configure audience verification (required).** After creating the Access application, set `ACCESS_AUD` so JWT verification only accepts tokens issued for this specific application.
+### Connect the Worker to your Access application
 
-1. Go to [**Zero Trust**](https://one.dash.cloudflare.com/) > **Access** > **Applications**
-2. Select your application and open **Additional settings**
-3. Copy the **Application Audience (AUD) Tag**
-4. Set it:
+Cloudflare Access issues a JWT after a user successfully signs in. Each JWT contains an application-specific Audience (`aud`) value.
+
+This Worker checks that value to confirm the token was issued for this Access application, rather than another Access application in the same Cloudflare account. Therefore, `ACCESS_AUD` is required.
+
+#### Find the AUD tag
+
+1. Open [Cloudflare Access applications](https://one.dash.cloudflare.com/?to=/:account/access/apps).
+2. Select **Configure** for the application protecting this Worker.
+3. Open **Additional settings**.
+4. Copy the **Application Audience (AUD) Tag**.
+
+#### Add it using Wrangler
 
 ```bash
 npm exec -- wrangler secret put ACCESS_AUD
-# Paste the AUD tag when prompted
 ```
 
-The Worker will reject all non-localhost requests, including deployed-site requests, until `ACCESS_AUD` is configured.
+Paste the AUD tag when prompted.
+
+#### Or add it using the dashboard
+
+1. Go to **Workers & Pages** and select this Worker.
+2. Open **Settings** > **Variables and Secrets**.
+3. Select **Add** and choose **Secret**.
+4. Enter `ACCESS_AUD` as the name.
+5. Paste the **Application Audience (AUD) Tag** as the value.
+6. Select **Deploy**.
+
+Reload the Worker URL and sign in again.
 
 ### 6. Deploy your first site
 
@@ -265,17 +283,17 @@ Local dev uses path-based routing automatically (`/sites/site-name/`). Access ve
 
 ## Troubleshooting
 
-| Problem                                          | Solution                                                                                                                                                                 |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| "Setup required: Enable Cloudflare Access"       | Open [Workers & Pages](https://dash.cloudflare.com/?to=/:account/workers-and-pages), select your Worker, and follow **Require company login** in the Setup section above |
-| "Cloudflare Access token could not be verified"  | Sign in again. If the problem continues, confirm `ACCESS_TEAM_DOMAIN` and `ACCESS_AUD` match your Access application                                                     |
-| "Could not create asset upload session"          | Check that `DISPATCH_NAMESPACE_API_TOKEN` is set with Workers Scripts Edit permission                                                                                    |
-| "Dispatch namespace not found"                   | Enable [Workers for Platforms](https://dash.cloudflare.com/?to=/:account/workers-for-platforms) and run `npm run setup`                                                  |
-| 404 on deployed sites                            | Ensure uploaded files include `index.html` at the root                                                                                                                   |
-| Database errors                                  | Tables auto-create on first request. Check the D1 database in the Cloudflare dashboard                                                                                   |
-| "Access verification is not configured"          | Set `ACCESS_TEAM_DOMAIN`. See **Find your team domain** in the Setup section above                                                                                       |
-| "Access audience verification is not configured" | Set `ACCESS_AUD` to the Application Audience (AUD) Tag. See **Require company login** in the Setup section above                                                         |
-| "Could not delete site from Cloudflare"          | Check that `DISPATCH_NAMESPACE_API_TOKEN` is valid and has Workers Scripts Edit permission                                                                               |
+| Problem                                                        | Solution                                                                                                                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "Setup required: Enable Cloudflare Access"                     | Open [Workers & Pages](https://dash.cloudflare.com/?to=/:account/workers-and-pages), select your Worker, and follow **Require company login** in the Setup section above |
+| "Cloudflare Access token could not be verified"                | Sign in again. If the problem continues, confirm `ACCESS_TEAM_DOMAIN` and `ACCESS_AUD` match your Access application                                                     |
+| "Could not create asset upload session"                        | Check that `DISPATCH_NAMESPACE_API_TOKEN` is set with Workers Scripts Edit permission                                                                                    |
+| "Dispatch namespace not found"                                 | Enable [Workers for Platforms](https://dash.cloudflare.com/?to=/:account/workers-for-platforms) and run `npm run setup`                                                  |
+| 404 on deployed sites                                          | Ensure uploaded files include `index.html` at the root                                                                                                                   |
+| Database errors                                                | Tables auto-create on first request. Check the D1 database in the Cloudflare dashboard                                                                                   |
+| "Access verification is not configured"                        | Set `ACCESS_TEAM_DOMAIN`. See **Find your team domain** in the Setup section above                                                                                       |
+| "Cloudflare Access setup is incomplete: ACCESS_AUD is missing" | Set `ACCESS_AUD` to the Application Audience (AUD) Tag. See **Connect the Worker to your Access application** in the Setup section above                                 |
+| "Could not delete site from Cloudflare"                        | Check that `DISPATCH_NAMESPACE_API_TOKEN` is valid and has Workers Scripts Edit permission                                                                               |
 
 **View logs:**
 

--- a/internal-sites-template/src/access.ts
+++ b/internal-sites-template/src/access.ts
@@ -201,11 +201,15 @@ export async function requireAccessIdentity(
 
 	if (!env.ACCESS_AUD?.trim()) {
 		return new Response(
-			"Access audience verification is not configured.\n\n" +
-				"Set ACCESS_AUD to the Application Audience (AUD) Tag for this Access application.\n" +
-				"Find it in Zero Trust > Access > Applications > your application > Additional settings.\n" +
-				"Then run: npm exec -- wrangler secret put ACCESS_AUD\n" +
-				"See the README for setup instructions.",
+			"Cloudflare Access setup is incomplete: ACCESS_AUD is missing.\n\n" +
+				"ACCESS_AUD ensures that Access tokens were issued specifically for this application, rather than another application in your Cloudflare account.\n\n" +
+				"Find the Application Audience (AUD) Tag here:\n" +
+				"https://one.dash.cloudflare.com/?to=/:account/access/apps\n\n" +
+				"Select Configure for the application protecting this Worker, then open Additional settings.\n\n" +
+				"Add the tag as the ACCESS_AUD secret:\n\n" +
+				"npm exec -- wrangler secret put ACCESS_AUD\n\n" +
+				"Alternatively, add it under:\n" +
+				"Workers & Pages > this Worker > Settings > Variables and Secrets",
 			{
 				status: 401,
 				headers: { "Content-Type": "text/plain; charset=utf-8" },

--- a/internal-sites-template/test/index.spec.ts
+++ b/internal-sites-template/test/index.spec.ts
@@ -238,9 +238,14 @@ describe("Internal Sites Platform", () => {
 
 		expect(response.status).toBe(401);
 		const body = await response.text();
-		expect(body).toContain("Access audience verification is not configured");
+		expect(body).toContain(
+			"Cloudflare Access setup is incomplete: ACCESS_AUD is missing",
+		);
 		expect(body).toContain("Application Audience (AUD) Tag");
 		expect(body).toContain("npm exec -- wrangler secret put ACCESS_AUD");
+		expect(body).toContain(
+			"Workers & Pages > this Worker > Settings > Variables and Secrets",
+		);
 		expect(body).not.toContain("Setup required: Enable Cloudflare Access");
 	});
 


### PR DESCRIPTION
## Summary
- explain why `ACCESS_AUD` is required and where to find the AUD tag
- document configuring the secret with Wrangler or the dashboard
- improve the missing-`ACCESS_AUD` runtime guidance and test coverage

## Testing
- `cd internal-sites-template && pnpm test` (30 tests passed)
- pre-push `pnpm run fix` hook passed