### PR TITLE
Fix main template end-to-end tests

### DIFF
--- a/agent-commerce-analytics-template/wrangler.jsonc
+++ b/agent-commerce-analytics-template/wrangler.jsonc
@@ -10,7 +10,8 @@
 	"upload_source_maps": true,
 	"assets": {
 		"directory": "./dist/client",
-		"not_found_handling": "single-page-application"
+		"not_found_handling": "single-page-application",
+		"run_worker_first": ["/api", "/api/*"]
 	},
 	"kv_namespaces": [
 		{

--- a/internal-sites-template/README.md
+++ b/internal-sites-template/README.md
@@ -195,11 +195,19 @@ npm test
 
 `npm test` runs fully locally in Miniflare. It requires no Cloudflare login or account, makes no Cloudflare API calls, and creates no remote resources.
 
+### Preview the local UI (no Cloudflare account required)
+
+```bash
+npm run dev
+```
+
+This starts the platform Worker with a local D1 database at [http://localhost:8787](http://localhost:8787). Dispatch namespaces cannot run locally, so deploying or opening uploaded sites requires the remote setup below.
+
 ### Local platform with remote site Workers
 
 To deploy test sites from the local UI, you need a Cloudflare account with [Workers for Platforms](https://dash.cloudflare.com/?to=/:account/workers-for-platforms) enabled.
 
-> **What runs where:** `npm run dev` starts the platform Worker at `http://localhost:8787`. The platform Worker and D1 run locally in Miniflare, and D1 data persists under `.wrangler/state`. The `dispatcher` binding keeps `"remote": true`, so the dispatch namespace and uploaded site Workers are real remote Cloudflare resources. Deploying a site from the local UI creates or updates a real Worker in your Cloudflare account.
+> **What runs where:** `npm run dev:remote` starts the platform Worker at `http://localhost:8787`. The platform Worker and D1 run locally in Miniflare, and D1 data persists under `.wrangler/state`. The `dispatcher` binding keeps `"remote": true`, so the dispatch namespace and uploaded site Workers are real remote Cloudflare resources. Deploying a site from the local UI creates or updates a real Worker in your Cloudflare account.
 
 **1. Install dependencies**
 
@@ -269,10 +277,10 @@ cp .dev.vars.example .dev.vars
 
 Edit `.dev.vars` and replace `your-token-here` with the real token.
 
-**7. Run locally**
+**7. Run locally with the remote dispatch namespace**
 
 ```bash
-npm run dev
+npm run dev:remote
 ```
 
 Open [http://localhost:8787/deploy](http://localhost:8787/deploy) to use the platform.

--- a/internal-sites-template/package.json
+++ b/internal-sites-template/package.json
@@ -47,9 +47,10 @@
 	"private": true,
 	"scripts": {
 		"build": "tsc",
-		"check": "npm run build && wrangler deploy --dry-run",
-		"deploy": "npm run setup && wrangler deploy",
-		"dev": "wrangler dev",
+		"check": "npm run build && wrangler deploy --dry-run --env=\"\"",
+		"deploy": "npm run setup && wrangler deploy --env=\"\"",
+		"dev": "wrangler dev --env local --local",
+		"dev:remote": "wrangler dev --env=\"\"",
 		"setup": "node scripts/setup.js",
 		"test": "node --test scripts/test-setup.js && vitest run"
 	}

--- a/internal-sites-template/scripts/test-setup.js
+++ b/internal-sites-template/scripts/test-setup.js
@@ -38,7 +38,10 @@ test("deploy provisions before invoking Wrangler deploy", () => {
 		fs.readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf-8"),
 	);
 
-	assert.equal(packageJson.scripts.deploy, "npm run setup && wrangler deploy");
+	assert.equal(
+		packageJson.scripts.deploy,
+		'npm run setup && wrangler deploy --env=""',
+	);
 });
 
 test("explicit setup propagates provisioning failures", () => {

--- a/internal-sites-template/wrangler.jsonc
+++ b/internal-sites-template/wrangler.jsonc
@@ -32,5 +32,30 @@
 		"ACCOUNT_ID": "",
 		"ACCESS_TEAM_DOMAIN": ""
 	},
+	"env": {
+		"local": {
+			"dispatch_namespaces": [
+				{
+					"binding": "dispatcher",
+					"namespace": "internal-sites",
+					"remote": true
+				}
+			],
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "internal-sites-platform-local",
+					"database_id": "00000000-0000-0000-0000-000000000000"
+				}
+			],
+			"vars": {
+				"DISPATCH_NAMESPACE_NAME": "internal-sites",
+				"SITE_DOMAIN": "internal-company.com",
+				"DEPLOY_PATH": "/deploy",
+				"ACCOUNT_ID": "",
+				"ACCESS_TEAM_DOMAIN": ""
+			}
+		}
+	},
 	"upload_source_maps": true
 }

--- a/playwright-tests/utils/template-server.ts
+++ b/playwright-tests/utils/template-server.ts
@@ -177,6 +177,12 @@ export class TemplateServerManager {
 			shell: true,
 			detached: true, // Create a new process group
 		});
+		let serverOutput = "";
+		const captureOutput = (chunk: Buffer | string) => {
+			serverOutput = `${serverOutput}${chunk.toString()}`.slice(-20000);
+		};
+		server.stdout?.on("data", captureOutput);
+		server.stderr?.on("data", captureOutput);
 
 		this.servers.set(templateName, server);
 
@@ -185,7 +191,17 @@ export class TemplateServerManager {
 		const healthCheckUrl = template.healthCheckPath
 			? `${baseUrl}${template.healthCheckPath}`
 			: baseUrl;
-		await this.waitForServer(healthCheckUrl, 30000); // 30 second timeout
+		try {
+			await this.waitForServer(
+				healthCheckUrl,
+				30000,
+				server,
+				() => serverOutput,
+			); // 30 second timeout
+		} catch (error) {
+			await this.stopServer(templateName);
+			throw error;
+		}
 
 		console.log(`Server for ${template.name} ready at ${baseUrl}`);
 		return baseUrl;
@@ -275,10 +291,25 @@ export class TemplateServerManager {
 		}
 	}
 
-	private async waitForServer(url: string, timeout: number): Promise<void> {
+	private async waitForServer(
+		url: string,
+		timeout: number,
+		server: ChildProcess,
+		getServerOutput: () => string,
+	): Promise<void> {
 		const start = Date.now();
 
 		while (Date.now() - start < timeout) {
+			if (server.exitCode !== null || server.signalCode !== null) {
+				const outcome =
+					server.exitCode !== null
+						? `code ${server.exitCode}`
+						: `signal ${server.signalCode}`;
+				throw new Error(
+					`Server process for ${url} exited with ${outcome}${this.formatServerOutput(getServerOutput())}`,
+				);
+			}
+
 			try {
 				const response = await fetch(url);
 				if (response.status < 500) {
@@ -292,8 +323,13 @@ export class TemplateServerManager {
 		}
 
 		throw new Error(
-			`Server at ${url} did not become ready within ${timeout}ms`,
+			`Server at ${url} did not become ready within ${timeout}ms${this.formatServerOutput(getServerOutput())}`,
 		);
+	}
+
+	private formatServerOutput(output: string): string {
+		const trimmedOutput = output.trim();
+		return trimmedOutput ? `\n\nServer output:\n${trimmedOutput}` : "";
 	}
 
 	private async runCommand(command: string, cwd: string): Promise<void> {

--- a/templates.json
+++ b/templates.json
@@ -109,7 +109,7 @@
       "package_json_hash": "d767d871776b0393536149ee47805f1350fe97cd"
     },
     "internal-sites-template": {
-      "package_json_hash": "b89bc33b8a9c6958383e1fa18bb1b1cc3b951936"
+      "package_json_hash": "eb448d4a65616ae5aecc862592e38e3ff87445d9"
     }
   }
 }


### PR DESCRIPTION
## Summary
- route Agent Commerce API navigation requests through the Worker before SPA assets
- add an account-free local development environment for the Internal Sites template while preserving remote dispatch development
- surface early dev-server exits and captured output in Playwright failures

## Testing
- `pnpm run check:templates`
- `pnpm run check:lockfiles`
- `pnpm run check:prettier`
- `npm test` and `npm run check` in both affected templates
- Agent Commerce Playwright suite (4 passed)
- Internal Sites local deploy UI smoke test
- pre-push full Turbo checks (53 tasks passed)