### PR TITLE
Fix template e2e harness on Windows

### DIFF
--- a/playwright-tests/fixtures.ts
+++ b/playwright-tests/fixtures.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { test as base } from "@playwright/test";
 import { Template, TemplateServerManager } from "./utils/template-server";
 
@@ -61,7 +62,7 @@ export const test = base.extend<TemplateFixtures, TemplateWorkerFixtures>({
 	},
 
 	template: async ({ templateServerManager }, use, testInfo) => {
-		const testFileName = testInfo.file.split("/").pop() || "";
+		const testFileName = path.basename(testInfo.file);
 		const templateName = testFileName.replace(".spec.ts", "");
 
 		const template = templateServerManager.getTemplate(templateName);

--- a/playwright-tests/utils/template-server.ts
+++ b/playwright-tests/utils/template-server.ts
@@ -190,6 +190,8 @@ export class TemplateServerManager {
 			{
 				cwd: template.path,
 				stdio: "pipe",
+				// Node throws EINVAL when spawning .cmd files without a shell (CVE-2024-27980)
+				shell: process.platform === "win32",
 				detached: process.platform !== "win32",
 				env: {
 					...process.env,


### PR DESCRIPTION
The Playwright harness currently cannot run any template spec on Windows, for two reasons:

1. `testInfo.file.split("/")` never matches Windows path separators, so every spec fails with "Template not found". Fixed with `path.basename`.
2. Spawning `pnpm.cmd` without a shell throws `EINVAL` on current Node versions due to the CVE-2024-27980 hardening. Fixed by enabling `shell` on win32 only; the spawn arguments are all internally generated (script name and numeric ports).

Verified on Windows 11 / Node 24: `d1-template.spec.ts` and a new template spec both fail without this change and pass with it. No behaviour change on POSIX platforms: the basename swap is equivalent there, and the shell option remains false.

AI assistance was used in diagnosing and drafting this change; I reviewed, ran, and take responsibility for it.