### PR TITLE
docs: welcome documentation and metadata-only contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,5 @@ pnpm playwright codgen
 ## Contributing
 
 We welcome template contributions! If there's a Workers template you think would be valuable, please read our [contributing guide](./CONTRIBUTING.md) and open an issue or pull request.
+
+Documentation improvements and metadata fixes are always welcome.


### PR DESCRIPTION
Adds a line under the Contributing section noting that documentation and metadata fixes are welcome.

No functional changes.