### PR TITLE
Fix live demo installs with Wrangler peer dependencies

### DIFF
--- a/cli/src/deployLiveDemos.ts
+++ b/cli/src/deployLiveDemos.ts
@@ -32,7 +32,7 @@ export default async function deployLiveDemos({
 	const templates = getPublishedTemplates(templateDirectory);
 	await Promise.all(
 		templates.map(({ path: templatePath }) => {
-			runCommand("npm install", templatePath);
+			runCommand("npm ci --legacy-peer-deps", templatePath);
 			runCommand("npm run build --if-present", templatePath);
 			runCommand("npm run deploy", templatePath);
 		}),


### PR DESCRIPTION
## Summary

Use deterministic npm installs for live-demo deployments and preserve the peer-dependency resolution used by the existing lockfiles.

This unblocks the main `Check and Deploy` workflow, which currently fails in `agent-commerce-analytics-template` because Wrangler 4.127 requires optional Workers types v5 while published templates still use v4.

## Validation

- `npm ci --legacy-peer-deps` succeeds against `agent-commerce-analytics-template/package-lock.json`
- `pnpm --dir cli build`
- `pnpm exec vitest run cli/test --passWithNoTests`
- Prettier check
