### PR TITLE
Configure Agent Commerce live demo KV namespace

### DIFF
--- a/agent-commerce-analytics-template/wrangler.jsonc
+++ b/agent-commerce-analytics-template/wrangler.jsonc
@@ -16,7 +16,7 @@
 	"kv_namespaces": [
 		{
 			"binding": "EVENT_STORE",
-			"id": "<REPLACE_WITH_YOUR_KV_NAMESPACE_ID>"
+			"id": "c1af5ae34d4a40d88d6732fd5f11160a"
 		}
 	],
 	"vars": {


### PR DESCRIPTION
## Summary

Configure the existing Cloudflare Templates account KV namespace for the published Agent Commerce Analytics live demo.

This unblocks the main `Check and Deploy` workflow, which otherwise attempts to deploy the literal `<REPLACE_WITH_YOUR_KV_NAMESPACE_ID>` placeholder.

## Validation

- `pnpm --dir agent-commerce-analytics-template run check`
- `pnpm run check:templates`
- Prettier check
