### PR TITLE
Add OpenAuth Hono peer dependency

### DIFF
--- a/openauth-template/package-lock.json
+++ b/openauth-template/package-lock.json
@@ -7,6 +7,7 @@
 			"name": "openauth-template",
 			"dependencies": {
 				"@openauthjs/openauth": "0.4.3",
+				"hono": "4.11.1",
 				"valibot": "1.2.0"
 			},
 			"devDependencies": {
@@ -709,6 +710,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -726,6 +730,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -743,6 +750,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -760,6 +770,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -777,6 +790,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -794,6 +810,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -811,6 +830,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -828,6 +850,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -845,6 +870,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -868,6 +896,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -891,6 +922,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -914,6 +948,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -937,6 +974,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -960,6 +1000,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -983,6 +1026,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1006,6 +1052,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1129,9 +1178,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+			"integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1159,6 +1208,62 @@
 				"arctic": "^2.2.2",
 				"hono": "^4.0.0"
 			}
+		},
+		"node_modules/@oslojs/asn1": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+			"integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@oslojs/binary": "1.0.0"
+			}
+		},
+		"node_modules/@oslojs/binary": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+			"integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@oslojs/crypto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+			"integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@oslojs/asn1": "1.0.0",
+				"@oslojs/binary": "1.0.0"
+			}
+		},
+		"node_modules/@oslojs/encoding": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+			"integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@oslojs/jwt": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
+			"integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@oslojs/encoding": "0.4.1"
+			}
+		},
+		"node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+			"integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@poppinss/colors": {
 			"version": "4.1.6",
@@ -1214,6 +1319,19 @@
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0-beta.3.tgz",
 			"integrity": "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw==",
 			"license": "MIT"
+		},
+		"node_modules/arctic": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/arctic/-/arctic-2.3.4.tgz",
+			"integrity": "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@oslojs/crypto": "1.0.1",
+				"@oslojs/encoding": "1.1.0",
+				"@oslojs/jwt": "0.2.0"
+			}
 		},
 		"node_modules/aws4fetch": {
 			"version": "1.0.20",
@@ -1317,6 +1435,15 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
+			"integrity": "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
 			}
 		},
 		"node_modules/jose": {
@@ -1453,7 +1580,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/openauth-template/package.json
+++ b/openauth-template/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@openauthjs/openauth": "0.4.3",
+		"hono": "4.11.1",
 		"valibot": "1.2.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,7 +647,10 @@ importers:
     dependencies:
       '@openauthjs/openauth':
         specifier: 0.4.3
-        version: 0.4.3(arctic@2.3.4)(hono@4.13.5)
+        version: 0.4.3(arctic@2.3.4)(hono@4.11.1)
+      hono:
+        specifier: 4.11.1
+        version: 4.11.1
       valibot:
         specifier: 1.2.0
         version: 1.2.0(typescript@5.9.3)
@@ -16729,12 +16732,12 @@ snapshots:
     dependencies:
       which: 3.0.1
 
-  '@openauthjs/openauth@0.4.3(arctic@2.3.4)(hono@4.13.5)':
+  '@openauthjs/openauth@0.4.3(arctic@2.3.4)(hono@4.11.1)':
     dependencies:
       '@standard-schema/spec': 1.0.0-beta.3
       arctic: 2.3.4
       aws4fetch: 1.0.20
-      hono: 4.13.5
+      hono: 4.11.1
       jose: 5.9.6
 
   '@opennextjs/aws@3.9.0':

--- a/templates.json
+++ b/templates.json
@@ -25,7 +25,7 @@
       "package_json_hash": "41f7e28d94bfec460d96af1535db4da5576d3010"
     },
     "openauth-template": {
-      "package_json_hash": "d49f51ac5606b012943a62c8d6d4122a01f15d07"
+      "package_json_hash": "03769155b877617952f53e9d5383e00b5a2e571f"
     },
     "r2-explorer-template": {
       "package_json_hash": "e6fc47f346da4baf3432d20a6ec7b531f6f38550"


### PR DESCRIPTION
## Summary

Declare OpenAuth's Hono peer dependency directly so isolated npm installs contain the modules Wrangler bundles.

This unblocks the published OpenAuth live-demo deployment after switching deployments to deterministic `npm ci` installs.

## Validation

- `npm ci --legacy-peer-deps`
- `npm run check` from `openauth-template`
- `pnpm run check:deps`
- `pnpm run check:lockfiles`
- Prettier check
