### PR TITLE
Install required peers for live demo deployments

### DIFF
--- a/cli/src/deployLiveDemos.ts
+++ b/cli/src/deployLiveDemos.ts
@@ -32,7 +32,7 @@ export default async function deployLiveDemos({
 	const templates = getPublishedTemplates(templateDirectory);
 	await Promise.all(
 		templates.map(({ path: templatePath }) => {
-			runCommand("npm ci --legacy-peer-deps", templatePath);
+			runCommand("npm install --force", templatePath);
 			runCommand("npm run build --if-present", templatePath);
 			runCommand("npm run deploy", templatePath);
 		}),


### PR DESCRIPTION
## Summary

Allow npm to resolve and install required peer dependencies while tolerating the existing Wrangler/Workers types peer-version mismatch.

`npm ci --legacy-peer-deps` fixed the Wrangler conflict but omitted runtime peers such as Hono, causing published OpenAuth and R2 Explorer deployments to fail. `npm install --force` succeeds for the Wrangler mismatch and installs those required peers.

## Validation

- `npm install --force` succeeds for Agent Commerce Analytics
- `npm install --force` installs Hono for R2 Explorer
- `pnpm --dir cli build`
- Prettier check
