### PR TITLE
Allow Workers AI time in live image test

### DIFF
--- a/playwright-tests/text-to-image-template.spec.ts
+++ b/playwright-tests/text-to-image-template.spec.ts
@@ -4,7 +4,7 @@ test("returns a PNG generated through the AI binding boundary", async ({
 	request,
 	templateUrl,
 }) => {
-	const response = await request.get(templateUrl);
+	const response = await request.get(templateUrl, { timeout: 90_000 });
 	expect(response.status()).toBe(200);
 	expect(response.headers()["content-type"]).toContain("image/png");
 	expect([...Buffer.from(await response.body()).subarray(0, 8)]).toEqual([


### PR DESCRIPTION
## Summary

Allow enough time for the live Workers AI image generation request. The deployed endpoint currently takes around 10 seconds, while Playwright's live action timeout is 5 seconds.

## Validation

- Targeted local Playwright test passes
- Targeted live Playwright test passes in 11.7 seconds
- Prettier check
