### PR TITLE
Publish Cloudflare Docs Voice Agent template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -112,7 +112,7 @@
       "package_json_hash": "26661fa56bcae892afaf849ba8cbdb9d4f79be43"
     },
     "voice-agent-template": {
-      "package_json_hash": "59f7b44e1a2e36f92ca4530fbd8ea58b063d4280"
+      "package_json_hash": "49cdbd36fa8fd269f88f67b84d0fc7e374a5ff87"
     }
   }
 }

--- a/voice-agent-template/package.json
+++ b/voice-agent-template/package.json
@@ -13,6 +13,8 @@
 		],
 		"docs_url": "https://developers.cloudflare.com/agents/",
 		"preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/8c4137a3-661e-46e9-d779-88c4d68ea200/public",
+		"preview_icon_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/7ee998bb-6d98-43ab-dd7f-3f2d85a89c00/public",
+		"publish": true,
 		"healthCheckPath": "/health",
 		"bindings": {
 			"VOICE_AGENT_TOKEN": {


### PR DESCRIPTION
## Summary

Publish the Cloudflare Docs Voice Agent template in the Dashboard gallery.

- Reuse the existing generic template SVG for `preview_icon_url`.
- Set `cloudflare.publish` to `true`.

The hosted WebP preview image was added in #1150.

## Validation

- `pnpm run check:templates`
- `pnpm run check:lockfiles`
- `pnpm run check:deps`
- `pnpm run validate-live-demo-links`
- Targeted live Playwright tests: 2 passed
- Prettier check
